### PR TITLE
chassis: Conditionally add TCP listener on OVSDB

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -72,9 +72,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     services = ['ovn-host']
     adapters_class = OVNChassisCharmRelationAdapters
     required_relations = ['certificates', 'ovsdb']
-    restart_map = {
-        '/etc/default/ovn-host': ['ovn-host'],
-    }
     python_version = 3
 
     def __init__(self, **kwargs):

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -49,7 +49,6 @@ def enable_metadata():
     nova_compute.publish_shared_secret()
     with charm.provide_charm_instance() as charm_instance:
         charm_instance.install()
-        charm_instance.render_with_interfaces(nova_compute)
         charm_instance.assess_status()
 
 
@@ -73,5 +72,8 @@ def configure_ovs():
     ovsdb = reactive.endpoint_from_flag('ovsdb.available')
     with charm.provide_charm_instance() as charm_instance:
         charm_instance.configure_ovs(ovsdb)
+        charm_instance.render_with_interfaces(
+            charm.optional_interfaces((ovsdb,),
+                                      'nova-compute.connected'))
         reactive.clear_flag('endpoint.certificates.changed')
         charm_instance.assess_status()

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -38,13 +38,13 @@ def enable_chassis_reactive_code():
 
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG)
 @reactive.when_not('nova-compute.connected')
-def disable_metadata():
-    reactive.clear_flag('charm.ovn-chassis.enable-openstack-metadata')
+def disable_openstack():
+    reactive.clear_flag('charm.ovn-chassis.enable-openstack')
 
 
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'nova-compute.connected')
-def enable_metadata():
-    reactive.set_flag('charm.ovn-chassis.enable-openstack-metadata')
+def enable_openstack():
+    reactive.set_flag('charm.ovn-chassis.enable-openstack')
     nova_compute = reactive.endpoint_from_flag('nova-compute.connected')
     nova_compute.publish_shared_secret()
     with charm.provide_charm_instance() as charm_instance:

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -135,6 +135,25 @@ class TestOVNChassisCharm(Helper):
             mock.call('ovs-vsctl', 'set', 'open', '.',
                       'external-ids:ovn-remote=dbsbconn'),
         ])
+        self.run.reset_mock()
+        self.target.enable_openstack = True
+        self.patch_object(ovn_charm.ovn, 'SimpleOVSDB')
+        self.target.configure_ovs(ovsdb_interface)
+        self.run.assert_has_calls([
+            mock.call('ovs-vsctl', 'set-ssl', mock.ANY, mock.ANY, mock.ANY),
+            mock.call('ovs-vsctl', 'set', 'open', '.',
+                      'external-ids:ovn-encap-type=geneve', '--',
+                      'set', 'open', '.',
+                      'external-ids:ovn-encap-ip=cluster_local_addr', '--',
+                      'set', 'open', '.',
+                      'external-ids:system-id=cluster_local_addr'),
+            mock.call('ovs-vsctl', 'set', 'open', '.',
+                      'external-ids:ovn-remote=dbsbconn'),
+            mock.call('ovs-vsctl', '--id', '@manager',
+                      'create', 'Manager', 'target="ptcp:6640:127.0.0.1"',
+                      '--', 'add', 'Open_vSwitch', '.', 'manager_options',
+                      '@manager'),
+        ])
 
     def test_configure_bridges(self):
         self.patch_object(ovn_charm.os_context, 'NeutronPortContext')

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -89,7 +89,6 @@ class TestOvnHandlers(test_utils.PatchHelper):
             'charm.ovn-chassis.enable-openstack-metadata')
         nova_compute.publish_shared_secret.assert_called_once_with()
         self.charm.install.assert_called_once_with()
-        self.charm.render_with_interfaces.assert_called_once_with(nova_compute)
         self.charm.assess_status.assert_called_once_with()
 
     def configure_ovs(self):
@@ -98,6 +97,8 @@ class TestOvnHandlers(test_utils.PatchHelper):
         ovsdb = mock.MagicMock()
         self.endpoint_from_flag.return_value = ovsdb
         self.charm.configure_ovs.assert_called_once_with(ovsdb)
+        self.charm.render_with_interfaces.assert_called_once_with(
+            (ovsdb),)
         self.clear_flag.assert_called_once_with(
             'endpoint.certificates.changed')
         self.charm.assess_status.assert_called_once_with()

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -38,9 +38,9 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'ovsdb.available',
                     'certificates.available',
                     'endpoint.certificates.changed'),
-                'disable_metadata': (
+                'disable_openstack': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,),
-                'enable_metadata': (
+                'enable_openstack': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                     'nova-compute.connected',),
                 'configure_bridges': (
@@ -48,7 +48,7 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'charm.installed',),
             },
             'when_not': {
-                'disable_metadata': ('nova-compute.connected',),
+                'disable_openstack': ('nova-compute.connected',),
             },
             'when_any': {
                 'configure_bridges': (
@@ -73,20 +73,20 @@ class TestOvnHandlers(test_utils.PatchHelper):
             self.charm
         self.provide_charm_instance().__exit__.return_value = None
 
-    def test_disable_metadata(self):
+    def test_disable_openstack(self):
         self.patch_object(handlers.reactive, 'clear_flag')
-        handlers.disable_metadata()
+        handlers.disable_openstack()
         self.clear_flag.assert_called_once_with(
-            'charm.ovn-chassis.enable-openstack-metadata')
+            'charm.ovn-chassis.enable-openstack')
 
-    def test_enable_metadata(self):
+    def test_enable_openstack(self):
         self.patch_object(handlers.reactive, 'endpoint_from_flag')
         self.patch_object(handlers.reactive, 'set_flag')
         nova_compute = mock.MagicMock()
         self.endpoint_from_flag.return_value = nova_compute
-        handlers.enable_metadata()
+        handlers.enable_openstack()
         self.set_flag.assert_called_once_with(
-            'charm.ovn-chassis.enable-openstack-metadata')
+            'charm.ovn-chassis.enable-openstack')
         nova_compute.publish_shared_secret.assert_called_once_with()
         self.charm.install.assert_called_once_with()
         self.charm.assess_status.assert_called_once_with()


### PR DESCRIPTION
When deployed with OpenStack, Nova expects the local OVSDB server
to listen to TCP port 6640 on localhost.  This is configurable in
os-vif, but the knob is not exposed through Nova.

Fix indentation level in ``configure_ovs`` method.

Closes-Bug: #1852200