### PR TITLE
Change ovn layer to work with os_actions in openstack layer

### DIFF
--- a/actions/ovn_os_actions.py
+++ b/actions/ovn_os_actions.py
@@ -15,14 +15,12 @@
 
 import sys
 
+
 sys.path.append('actions')
-sys.path.append('lib')
+
 
 import os_actions
-import charms.ovn_central  # noqa
 
 
-# The OVN charms has different placement of the charm class and we need this
-# glue to make the actions provided by `layer-openstack` to work.
 if __name__ == "__main__":
     sys.exit(os_actions.main(sys.argv))

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -21,7 +21,7 @@ import charms_openstack.bus
 import charms_openstack.charm as charm
 
 
-charms_openstack.bus.discover(os.path.join('lib', 'charms'))
+charms_openstack.bus.discover()
 OVN_CHASSIS_ENABLE_HANDLERS_FLAG = 'charm.ovn.chassis.enable-handlers'
 
 


### PR DESCRIPTION
The openstack layer [2] has a default implementation of actions which
are implemented in the os_actions modules.  This uses
charms_openstac.bus.discover() to locate and import the concrete charm
class and instantiate it.  This is needed for the default actions to
work.  The linked bug [1] is due to the module charms.ovn_central not
existing as the two dependent charm layers (ovn-chassis and
ovn-dedicated-chassis) implement them in uniquely named modules
(ovn_chassis and ovn_dedicated_chassis).  The bug [1] is fixed by
modifying the charm layers to place their concrete charm class modules
into /lib/charm/openstack upon which everything will 'just work'.

[1] LP bug: https://bugs.launchpad.net/charm-ovn-chassis/+bug/1861069
[2] https://review.opendev.org/p/openstack/charm-layer-openstack