### PR TITLE
Change how bridge interface mappings are configured

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ options:
       Note that updating this setting to a source that is known to
       provide a later version of Ceph will trigger a software
       upgrade.
-  interface-bridge-mappings:
+  bridge-interface-mappings:
     type: string
     default:
     description: >
@@ -43,7 +43,7 @@ options:
       An example value mapping two network interface mac address to two ovs
       bridges would be:
 
-          00:00:5e:00:00:42:br-internet enp3s0f0:br-provider
+          br-internet:00:00:5e:00:00:42 br-provider:enp3s0f0
 
 
       Note: OVN gives you distributed East/West and highly available
@@ -72,7 +72,7 @@ options:
 
       Each charm unit will evaluate each key-value pair and determine if the
       configuration is relevant for the host it is running on based on matches
-      found in the `interface-bridge-mappings` configuration option.
+      found in the `bridge-interface-mappings` configuration option.
 
       If a match is found the bridge will be created if it does not already
       exist, the matched interface will be added to it and the mapping will be
@@ -85,5 +85,5 @@ options:
           physnet1:br-internet physnet2:br-provider
 
       NOTE: Values in this configuration option will only have effect for units
-      that have a interface referenced in the `interface-bridge-mappings`
+      that have a interface referenced in the `bridge-interface-mappings`
       configuration option.

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -161,9 +161,9 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
         # build map of bridge config with existing interfaces on host
         ifbridges = collections.defaultdict(list)
-        config_ifbm = self.config['interface-bridge-mappings'] or ''
+        config_ifbm = self.config['bridge-interface-mappings'] or ''
         for pair in config_ifbm.split():
-            ifname_or_mac, bridge = pair.rsplit(':', 1)
+            bridge, ifname_or_mac = pair.split(':', 1)
             ifbridges[bridge].append(ifname_or_mac)
         for br in ifbridges.keys():
             # resolve mac addresses to interface names

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -55,13 +55,13 @@ def enable_openstack():
 
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'charm.installed')
 @reactive.when_any('config.changed.ovn-bridge-mappings',
-                   'config.changed.interface-bridge-mappings',
+                   'config.changed.bridge-interface-mappings',
                    'run-default-upgrade-charm')
 def configure_bridges():
     with charm.provide_charm_instance() as charm_instance:
         charm_instance.configure_bridges()
         reactive.clear_flag('config.changed.ovn-bridge-mappings')
-        reactive.clear_flag('config.changed.interface-bridge-mappings')
+        reactive.clear_flag('config.changed.bridge-interface-mappings')
         charm_instance.assess_status()
 
 

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -182,7 +182,7 @@ class TestOVNChassisCharm(Helper):
         self.NeutronPortContext.return_value = npc
         self.patch_target('config')
         self.config.__getitem__.side_effect = [
-            '00:01:02:03:04:05:br-provider eth5:br-other',
+            'br-provider:00:01:02:03:04:05 br-other:eth5',
             'provider:br-provider other:br-other']
         self.patch_object(ovn_charm.ovn, 'SimpleOVSDB')
         bridges = mock.MagicMock()

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -54,7 +54,7 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
             'when_any': {
                 'configure_bridges': (
                     'config.changed.ovn-bridge-mappings',
-                    'config.changed.interface-bridge-mappings',
+                    'config.changed.bridge-interface-mappings',
                     'run-default-upgrade-charm',),
             },
         }


### PR DESCRIPTION
Replace the `interface-bridge-mappings` configuration option with
a `bridge-interface-mappings` configuration option.

The new configuration option also takes its arguments in the
reverse order of the original.

This is done based on power user feedback and to align with how
existing network charms are configured.  LP: #1850956