### PR TITLE
Fix OVS reconfiguration, avoid uneccessary restarts

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -117,7 +117,11 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             break
 
     def configure_ovs(self, ovsdb_interface):
+        # NOTE(fnordahl): Due to what is probably a bug in Open vSwitch
+        # subsequent calls to ``ovs-vsctl set-ssl`` will hang indefiniently
+        # Work around this by passing ``--no-wait``.
         self.run('ovs-vsctl',
+                 '--no-wait',
                  'set-ssl',
                  ovn_key(self.adapters_instance),
                  ovn_cert(self.adapters_instance),
@@ -152,7 +156,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                          'create', 'Manager', 'target="{}"'.format(target),
                          '--', 'add', 'Open_vSwitch', '.', 'manager_options',
                          '@manager')
-        self.restart_all()
 
     def configure_bridges(self):
         # we use the resolve_port method of NeutronPortContext to translate

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -118,7 +118,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     def configure_ovs(self, ovsdb_interface):
         # NOTE(fnordahl): Due to what is probably a bug in Open vSwitch
-        # subsequent calls to ``ovs-vsctl set-ssl`` will hang indefiniently
+        # subsequent calls to ``ovs-vsctl set-ssl`` will hang indefinitely
         # Work around this by passing ``--no-wait``.
         self.run('ovs-vsctl',
                  '--no-wait',

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -38,11 +38,12 @@ def enable_chassis_reactive_code():
 
 
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG)
-@reactive.when_not('nova-compute.connected')
+@reactive.when_not('run-default-update-status', 'nova-compute.connected')
 def disable_openstack():
     reactive.clear_flag('charm.ovn-chassis.enable-openstack')
 
 
+@reactive.when_not('run-default-update-status')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'nova-compute.connected')
 def enable_openstack():
     reactive.set_flag('charm.ovn-chassis.enable-openstack')
@@ -65,10 +66,10 @@ def configure_bridges():
         charm_instance.assess_status()
 
 
+@reactive.when_not('run-default-update-status')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                'ovsdb.available',
-               'certificates.available',
-               'endpoint.certificates.changed')
+               'certificates.available')
 def configure_ovs():
     ovsdb = reactive.endpoint_from_flag('ovsdb.available')
     with charm.provide_charm_instance() as charm_instance:
@@ -76,6 +77,5 @@ def configure_ovs():
         charm_instance.render_with_interfaces(
             charm.optional_interfaces((ovsdb,),
                                       'nova-compute.connected'))
-        reactive.clear_flag('endpoint.certificates.changed')
         reactive.set_flag('config.rendered')
         charm_instance.assess_status()

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -131,7 +131,8 @@ class TestOVNChassisCharm(Helper):
         ovsdb_interface.cluster_local_addr = cluster_local_addr
         self.target.configure_ovs(ovsdb_interface)
         self.run.assert_has_calls([
-            mock.call('ovs-vsctl', 'set-ssl', mock.ANY, mock.ANY, mock.ANY),
+            mock.call('ovs-vsctl', '--no-wait', 'set-ssl',
+                      mock.ANY, mock.ANY, mock.ANY),
             mock.call('ovs-vsctl', 'set', 'open', '.',
                       'external-ids:ovn-encap-type=geneve', '--',
                       'set', 'open', '.',
@@ -150,7 +151,8 @@ class TestOVNChassisCharm(Helper):
         managers.find.assert_called_once_with(
             'target="ptcp:6640:127.0.0.1"')
         self.run.assert_has_calls([
-            mock.call('ovs-vsctl', 'set-ssl', mock.ANY, mock.ANY, mock.ANY),
+            mock.call('ovs-vsctl', '--no-wait', 'set-ssl',
+                      mock.ANY, mock.ANY, mock.ANY),
             mock.call('ovs-vsctl', 'set', 'open', '.',
                       'external-ids:ovn-encap-type=geneve', '--',
                       'set', 'open', '.',

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -37,8 +37,7 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                 'configure_ovs': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                     'ovsdb.available',
-                    'certificates.available',
-                    'endpoint.certificates.changed'),
+                    'certificates.available'),
                 'disable_openstack': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,),
                 'enable_openstack': (
@@ -49,7 +48,10 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'charm.installed',),
             },
             'when_not': {
-                'disable_openstack': ('nova-compute.connected',),
+                'disable_openstack': ('run-default-update-status',
+                                      'nova-compute.connected',),
+                'enable_openstack': ('run-default-update-status',),
+                'configure_ovs': ('run-default-update-status',),
             },
             'when_any': {
                 'configure_bridges': (


### PR DESCRIPTION
Due to what is probably a bug in Open vSwitch OVS reconfiguration
was gated on certificate changes.  Allow reconfiguration even when
certificate data is not changed.

Remove uneccessary restart of all services on configuration change.

Add gating to not run on update-status where appropriate.