### PR TITLE
Enable the default select release handler

### DIFF
--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -31,6 +31,7 @@ def enable_chassis_reactive_code():
         'charm.installed',
         'config.changed',
         'config.rendered',
+        'charm.default-select-release',
         'update-status',
         'upgrade-charm',
         'certificates.available',

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -26,6 +26,7 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
             'charm.installed',
             'config.changed',
             'config.rendered',
+            'charm.default-select-release',
             'update-status',
             'upgrade-charm',
             'certificates.available',


### PR DESCRIPTION
A select release handler must be enabled in order for the provide
charm class instance magic in `charms.openstack` to work.

Each specialized charm class encapsulates the necessary delta in
code for the charm to operate on a specific release.