### PR TITLE
Remove charm provided init script for metadata agent

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -322,15 +322,9 @@ class BaseUssuriOVNChassisCharm(BaseOVNChassisCharm):
         super().__init__(**kwargs)
         if self.enable_openstack:
             metadata_agent = 'neutron-ovn-metadata-agent'
-            # TODO: replace with ussuri ``neutron-ovn-metadata-agent`` pkg
-            self.packages.extend(['python3-neutron', 'haproxy'])
+            self.packages.extend([metadata_agent])
             self.services.append(metadata_agent)
             self.restart_map.update({
-                '/etc/init.d/neutron-ovn-metadata-agent': [],
-                '/etc/systemd/system/neutron-ovn-metadata-agent.service': [],
                 '/etc/neutron/neutron_ovn_metadata_agent.ini': [
                     metadata_agent],
-            })
-            self.permission_override_map.update({
-                '/etc/init.d/neutron-ovn-metadata-agent': 0o755,
             })

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -98,15 +98,14 @@ class TestOVNChassisCharm(Helper):
                           return_value=True)
         c = ovn_charm.BaseUssuriOVNChassisCharm()
         self.assertEquals(c.packages, [
-            'ovn-host', 'python3-neutron', 'haproxy'
+            'ovn-host', 'neutron-ovn-metadata-agent'
         ])
         self.assertEquals(c.services, [
             'ovn-host', 'neutron-ovn-metadata-agent'])
         self.assertDictEqual(c.restart_map, {
-            '/etc/init.d/neutron-ovn-metadata-agent': [],
             '/etc/neutron/neutron_ovn_metadata_agent.ini': [
                 'neutron-ovn-metadata-agent'],
-            '/etc/systemd/system/neutron-ovn-metadata-agent.service': []})
+        })
 
     def test_run(self):
         self.patch_object(ovn_charm.subprocess, 'run')


### PR DESCRIPTION
As an interrim solution this was provided by the charm awaiting
proper delivery through the Ubuntu package.