### PR TITLE
Fix package/service adaption in specialized classes

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -67,8 +67,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         ]),
     }
     release_pkg = 'ovn-host'
-    packages = ['ovn-host']
-    services = ['ovn-host']
     adapters_class = OVNChassisCharmRelationAdapters
     required_relations = ['certificates', 'ovsdb']
     python_version = 3
@@ -76,6 +74,11 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # NOTE: we must initialize the packages and services variables as
+        # instance variables as we are extending them in the release
+        # specialized class instances and can not rely on class variables.
+        self.packages = ['ovn-host']
+        self.services = ['ovn-host']
         try:
             charms_openstack.adapters.config_property(ovn_key)
             charms_openstack.adapters.config_property(ovn_cert)

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -31,7 +31,6 @@ def enable_chassis_reactive_code():
         'charm.installed',
         'config.changed',
         'config.rendered',
-        'charm.default-select-release',
         'update-status',
         'upgrade-charm',
         'certificates.available',

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -43,9 +43,9 @@ class TestOVNConfigProperties(test_utils.PatchHelper):
 
 class Helper(test_utils.PatchHelper):
 
-    def setUp(self):
+    def setUp(self, release=None):
         super().setUp()
-        self.patch_release(ovn_charm.BaseOVNChassisCharm.release)
+        self.patch_release(release or 'train')
         self.patch_object(ovn_charm.reactive, 'is_flag_set',
                           return_value=False)
         self.patch_object(
@@ -71,7 +71,7 @@ class Helper(test_utils.PatchHelper):
         setattr(self, attr, started)
 
 
-class TestOVNChassisCharm(Helper):
+class TestTrainOVNChassisCharm(Helper):
 
     def test_optional_openstack_metadata_train(self):
         self.assertEquals(self.target.packages, ['ovn-host'])
@@ -87,6 +87,12 @@ class TestOVNChassisCharm(Helper):
         ])
         self.assertEquals(c.services, [
             'ovn-host', 'networking-ovn-metadata-agent'])
+
+
+class TestUssuriOVNChassisCharm(Helper):
+
+    def setUp(self):
+        super().setUp(release='ussuri')
 
     def test_optional_openstack_metadata_ussuri(self):
         self.assertEquals(self.target.packages, ['ovn-host'])
@@ -106,6 +112,9 @@ class TestOVNChassisCharm(Helper):
             '/etc/neutron/neutron_ovn_metadata_agent.ini': [
                 'neutron-ovn-metadata-agent'],
         })
+
+
+class TestOVNChassisCharm(Helper):
 
     def test_run(self):
         self.patch_object(ovn_charm.subprocess, 'run')


### PR DESCRIPTION
When the charm code executes the default release selector code
will instantiate all incarnations of the non-abstract charm
classes as a side effect of figuring out which one to use.

At present we set the package and service list as class variables,
subsequently the specialized class initializers will extend on
the same variables and we end up with a charm class with an
incorrect package and service specification.

To fix this we assign the package and service variable in the OVN
Charm base class initializer.

We also remove activation of the default select release handler
in the layer as it will execute too late.  Each individual charm
must execute the handler as early as possible.