### PR TITLE
Add NRPE checks for services

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -229,3 +229,17 @@ options:
       integration bridge on the hypervisor and during a migration the operator
       may want to shut down and clean up after the ML2 OVS components before
       the `ovn-controller` takes over and reprograms the bridge flow rules.
+  nagios_context:
+    default: "juju"
+    type: string
+    description: |
+      A string that will be prepended to instance name to set the host name
+      in nagios. So for instance the hostname would be something like:
+          juju-myservice-0
+      If you're running multiple environments with the same services in them
+      this allows you to differentiate between them.
+  nagios_servicegroups:
+    default: ""
+    type: string
+    description: |
+      Comma separated list of nagios servicegroups for the service checks.

--- a/layer.yaml
+++ b/layer.yaml
@@ -2,6 +2,7 @@ includes:
   - layer:openstack
   - interface:ovsdb
   - interface:rabbitmq
+  - interface:nrpe-external-master
 exclude: 
   - .gitignore
   - .stestr.conf

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -116,7 +116,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     enable_openstack = False
     bridges_key = 'bridge-interface-mappings'
     nrpe_check_services = []
-    metadata_agent = 'neutron-ovn-metadata-agent'
 
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""
@@ -623,8 +622,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         else:
             primary = False
         charm_nrpe = nrpe.NRPE(hostname=hostname, primary=primary)
-        if reactive.is_flag_set('nova-compute.available'):
-            self.nrpe_check_services.append(self.metadata_agent)
         nrpe.add_init_service_checks(
             charm_nrpe, self.nrpe_check_services, current_unit)
         charm_nrpe.write()
@@ -641,19 +638,20 @@ class BaseTrainOVNChassisCharm(BaseOVNChassisCharm):
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""
         super().__init__(**kwargs)
-        if self.enable_openstack:
-            self.metadata_agent = 'networking-ovn-metadata-agent'
-            self.packages.extend(['networking-ovn-metadata-agent', 'haproxy'])
-            self.services.append(self.metadata_agent)
-            self.restart_map.update({
-                '/etc/neutron/'
-                'networking_ovn_metadata_agent.ini': [self.metadata_agent],
-            })
         self.nrpe_check_services = [
             'ovn-host',
             'ovs-vswitchd',
             'ovsdb-server',
         ]
+        if self.enable_openstack:
+            metadata_agent = 'networking-ovn-metadata-agent'
+            self.nrpe_check_services.append(metadata_agent)
+            self.packages.extend(['networking-ovn-metadata-agent', 'haproxy'])
+            self.services.append(metadata_agent)
+            self.restart_map.update({
+                '/etc/neutron/'
+                'networking_ovn_metadata_agent.ini': [metadata_agent],
+            })
 
 
 class BaseUssuriOVNChassisCharm(BaseOVNChassisCharm):
@@ -663,16 +661,17 @@ class BaseUssuriOVNChassisCharm(BaseOVNChassisCharm):
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""
         super().__init__(**kwargs)
-        if self.enable_openstack:
-            self.metadata_agent = 'neutron-ovn-metadata-agent'
-            self.packages.extend([self.metadata_agent])
-            self.services.append(self.metadata_agent)
-            self.restart_map.update({
-                '/etc/neutron/neutron_ovn_metadata_agent.ini': [
-                    self.metadata_agent],
-            })
         self.nrpe_check_services = [
             'ovn-controller',
-            'ovsdb-server',
             'ovs-vswitchd',
+            'ovsdb-server',
         ]
+        if self.enable_openstack:
+            metadata_agent = 'neutron-ovn-metadata-agent'
+            self.nrpe_check_services.append(metadata_agent)
+            self.packages.extend([metadata_agent])
+            self.services.append(metadata_agent)
+            self.restart_map.update({
+                '/etc/neutron/neutron_ovn_metadata_agent.ini': [
+                    metadata_agent],
+            })

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -116,6 +116,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     enable_openstack = False
     bridges_key = 'bridge-interface-mappings'
     nrpe_check_services = []
+    metadata_agent = 'neutron-ovn-metadata-agent'
 
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,3 +11,8 @@ series: []
 requires:
   amqp:
     interface: rabbitmq
+provides:
+  nrpe-external-master:
+    interface: nrpe-external-master
+    scope: container
+

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -97,3 +97,15 @@ def configure_ovs():
                                       'amqp.connected'))
         reactive.set_flag('config.rendered')
         charm_instance.assess_status()
+
+
+@reactive.when_none('charm.paused', 'is-update-status-hook')
+@reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'config.rendered')
+@reactive.when_any('config.changed.nagios_context',
+                   'config.changed.nagios_servicegroups',
+                   'endpoint.nrpe-external-master.changed',
+                   'nrpe-external-master.available')
+def configure_nrpe():
+    """Handle config-changed for NRPE options."""
+    with charm.provide_charm_instance() as charm_instance:
+        charm_instance.render_nrpe()

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -35,6 +35,7 @@ class _fake_decorator(object):
 
 sys.modules['charmhelpers.contrib.network.ovs'] = mock.MagicMock()
 sys.modules['charmhelpers.contrib.network.ovs.ovsdb'] = mock.MagicMock()
+sys.modules['charmhelpers.contrib.charmsupport.nrpe'] = mock.MagicMock()
 charms.leadership = mock.MagicMock()
 sys.modules['charms.leadership'] = charms.leadership
 charms.reactive = mock.MagicMock()

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -135,6 +135,9 @@ class TestTrainOVNChassisCharm(Helper):
         ])
         self.assertEquals(self.target.services, [
             'ovn-host', 'networking-ovn-metadata-agent'])
+        self.assertEquals(self.target.nrpe_check_services, [
+            'ovn-host', 'ovs-vswitchd', 'ovsdb-server',
+            'networking-ovn-metadata-agent'])
 
 
 class TestUssuriOVNChassisCharm(Helper):
@@ -153,6 +156,9 @@ class TestUssuriOVNChassisCharm(Helper):
                 'neutron-ovn-metadata-agent'],
             '/etc/openvswitch/system-id.conf': [],
         })
+        self.assertEquals(self.target.nrpe_check_services, [
+            'ovn-controller', 'ovs-vswitchd', 'ovsdb-server',
+            'neutron-ovn-metadata-agent'])
 
 
 class TestDPDKOVNChassisCharm(Helper):
@@ -463,8 +469,7 @@ class TestOVNChassisCharm(Helper):
         self.add_init_service_checks.assert_has_calls([
             mock.call().add_init_service_checks(
                 mock.ANY,
-                ['ovn-controller', 'ovsdb-server', 'ovs-vswitchd',
-                 'neutron-ovn-metadata-agent'],
+                ['ovn-controller', 'ovs-vswitchd', 'ovsdb-server'],
                 mock.ANY
             ),
         ])

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -456,6 +456,22 @@ class TestOVNChassisCharm(Helper):
                       '@manager'),
         ])
 
+    def test_render_nrpe(self):
+        self.patch_object(ovn_charm.nrpe, 'NRPE')
+        self.patch_object(ovn_charm.nrpe, 'add_init_service_checks')
+        self.target.render_nrpe()
+        self.add_init_service_checks.assert_has_calls([
+            mock.call().add_init_service_checks(
+                mock.ANY,
+                ['ovn-controller', 'ovsdb-server', 'ovs-vswitchd',
+                 'neutron-ovn-metadata-agent'],
+                mock.ANY
+            ),
+        ])
+        self.NRPE.assert_has_calls([
+            mock.call().write(),
+        ])
+
     def test_configure_bridges(self):
         self.patch_object(ovn_charm.os_context, 'BridgePortInterfaceMap')
         dict_bpi = {


### PR DESCRIPTION
Adds the nrpe-external-master layer and checks for services managed by
this charm.

func-test-pr: https://github.com/openstack-charmers/zaza-openstack-tests/pull/433

Closes-Bug: #1896674