### PR TITLE
Deffer TLS processing when there are no TLS objects

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -311,6 +311,14 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         # The default handler in ``OpenStackCharm`` class does the CA only
         tls_objects = self.get_certs_and_keys(
             certificates_interface=certificates_interface)
+        if not tls_objects:
+            # We have no configuration settings ssl_* nor a certificates
+            # relation to vault.
+            # Avoid LP Bug#1900457
+            ch_core.hookenv.log(
+                'No TLS objects available yet. Deferring TLS processing',
+                level=ch_core.hookenv.DEBUG)
+            return
 
         expected_cn = self.get_ovs_hostname()
 

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -374,6 +374,13 @@ class TestOVNChassisCharm(Helper):
                 'fakekey',
                 cn='host')
 
+    def test_configure_tls_not_ready(self):
+        self.patch_target('get_certs_and_keys')
+        self.get_certs_and_keys.return_value = None
+        self.target.configure_cert = mock.MagicMock()
+        self.target.configure_tls()
+        self.target.configure_cert.assert_not_called()
+
     def test__format_addr(self):
         self.assertEquals('1.2.3.4', self.target._format_addr('1.2.3.4'))
         self.assertEquals(


### PR DESCRIPTION
Avoid the call to get_ovs_hostname and LP Bug# 1900457 when there are no
TLS objects. i.e. certificates relation to vault or ssl_* parameters
set.

Closes-Bug: #1900457