### PR TITLE
SR-IOV: match on PCI address, don't do runtime config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -127,7 +127,7 @@ options:
     type: boolean
     default: false
     description: |
-      NOTE: Support for hardware offload in conjunction with OVN is a
+      NOTE: Support for hardware offload in conjunction with OVN is an
       experimental feature.
       .
       Enable support for hardware offload of flows from Open vSwitch to
@@ -139,6 +139,10 @@ options:
       each unit.
       .
       This option must not be enabled with either enable-sriov or enable-dpdk.
+      .
+      NOTE: Changing this value will not perform hardware specific adaption. A
+      manual restart of the hardware specific adaption service or reboot of the
+      system is required to apply configuration.
   enable-sriov:
     type: boolean
     default: false
@@ -210,9 +214,9 @@ options:
       Multiple devices can be configured by providing multi values delimited by
       spaces.
       .
-      NOTE: Changing this value will disrupt networking on all SR-IOV capable
-      interfaces for blanket configuration or listed interfaces when per-device
-      configuration is used.
+      NOTE: Changing this value will have no effect on runtime configuration. A
+      manual restart of the `sriov-netplan-shim` service or reboot of the
+      system is required to apply configuration.
   new-units-paused:
     type: boolean
     default: false

--- a/templates/interfaces.yaml
+++ b/templates/interfaces.yaml
@@ -1,5 +1,7 @@
 interfaces:
-  {% for interface, numvfs in options.sriov_device.items() -%}
-  {{ interface }}:
-    num_vfs: {{ numvfs }}
+  {% for _, pcidnvfs in options.sriov_device.get_map.items() -%}
+  {{ pcidnvfs.device.interface_name }}:
+    match:
+      pciaddress: {{ pcidnvfs.device.pci_address }}
+    num_vfs: {{ pcidnvfs.numvfs }}
   {% endfor -%}

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -38,10 +38,6 @@ class TestOVNConfigurationAdapter(test_utils.PatchHelper):
         }
         self.patch('charmhelpers.contrib.openstack.context.SRIOVContext',
                    name='SRIOVContext')
-        self.SRIOVContext.return_value = lambda: {
-            'eth0': 16,
-            'eth1': 32,
-        }
         self.target = ovn_charm.OVNConfigurationAdapter(
             charm_instance=self.charm_instance)
 
@@ -61,8 +57,7 @@ class TestOVNConfigurationAdapter(test_utils.PatchHelper):
         self.assertEquals(self.target.dpdk_device.driver, 'fakedriver')
 
     def test_sriov_device(self):
-        self.assertDictEqual(self.target.sriov_device,
-                             {'eth0': 16, 'eth1': 32})
+        self.assertEquals(self.target.sriov_device, self.SRIOVContext())
 
 
 class Helper(test_utils.PatchHelper):
@@ -642,7 +637,7 @@ class TestSRIOVOVNChassisCharm(Helper):
             'neutron-ovn-metadata-agent',
         ])
         self.assertDictEqual(self.target.restart_map, {
-            '/etc/sriov-netplan-shim/interfaces.yaml': ['sriov-netplan-shim'],
+            '/etc/sriov-netplan-shim/interfaces.yaml': [],
             '/etc/neutron/neutron.conf': ['neutron-sriov-agent'],
             '/etc/neutron/plugins/ml2/sriov_agent.ini': [
                 'neutron-sriov-agent'],
@@ -679,8 +674,7 @@ class TestHWOffloadChassisCharm(Helper):
             'mlnx-switchdev-mode',
         ])
         self.assertDictEqual(self.target.restart_map, {
-            '/etc/sriov-netplan-shim/interfaces.yaml': [
-                'sriov-netplan-shim', 'mlnx-switchdev-mode'],
+            '/etc/sriov-netplan-shim/interfaces.yaml': [],
             '/etc/openvswitch/system-id.conf': [],
         })
         self.assertEquals(self.target.group, 'root')


### PR DESCRIPTION
Populate the sriov-netplan-shim interfaces.yaml config with PCI
address of interfaces. This is necessary as the VFs may be
configured at a time in the boot sequence where interface naming
has not settled yet.

Stop doing runtime reconfiguration of SR-IOV, in addition to being
detrimental to any virtual machine instance consuming the VF this
will break NIC firmware in some configurations.

Merge after:
https://github.com/juju/charm-helpers/pull/549

Closes-Bug: #1908351