### PR TITLE
Add disable-mlockall config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -250,3 +250,20 @@ options:
     type: string
     description: |
       Comma separated list of nagios servicegroups for the service checks.
+  disable-mlockall:
+    type: boolean
+    default:
+    description: |
+      Disable Open vSwitch use of mlockall().
+      .
+      When mlockall() is enabled, all of ovs-vswitchd's process memory is
+      locked into physical RAM and prevented from paging. This avoids network
+      interruptions but can lead to memory exhaustion in memory-constrained
+      environments.
+      .
+      By default, the charm will disable mlockall() if it is running in a
+      container. Otherwise, the charm will default to mlockall() enabled if
+      it is not running in a container.
+      .
+      Changing this config option will restart openvswitch-switch, resulting
+      in an expected data plane outage while the service restarts.

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -91,13 +91,13 @@ def configure_ovs():
         if reactive.is_flag_set('config.changed.enable-dpdk'):
             # Install required packages and/or run update-alternatives
             charm_instance.install()
-        charm_instance.configure_ovs(
-            ','.join(ovsdb.db_sb_connection_strs),
-            reactive.is_flag_set('config.changed.disable-mlockall'))
         charm_instance.render_with_interfaces(
             charm.optional_interfaces((ovsdb,),
                                       'nova-compute.connected',
                                       'amqp.connected'))
+        charm_instance.configure_ovs(
+            ','.join(ovsdb.db_sb_connection_strs),
+            reactive.is_flag_set('config.changed.disable-mlockall'))
         reactive.set_flag('config.rendered')
         charm_instance.assess_status()
 

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -91,7 +91,9 @@ def configure_ovs():
         if reactive.is_flag_set('config.changed.enable-dpdk'):
             # Install required packages and/or run update-alternatives
             charm_instance.install()
-        charm_instance.configure_ovs(','.join(ovsdb.db_sb_connection_strs))
+        charm_instance.configure_ovs(
+            ','.join(ovsdb.db_sb_connection_strs),
+            reactive.is_flag_set('config.changed.disable-mlockall'))
         charm_instance.render_with_interfaces(
             charm.optional_interfaces((ovsdb,),
                                       'nova-compute.connected',

--- a/templates/openvswitch-switch
+++ b/templates/openvswitch-switch
@@ -1,0 +1,11 @@
+# This is a POSIX shell fragment                -*- sh -*-
+###############################################################################
+# [ WARNING ]
+# Configuration file maintained by Juju. Local changes may be overwritten.
+# Configuration managed by neutron-openvswitch charm
+# Service restart triggered by remote application: {{ restart_trigger }}
+#                                                  {{ restart_trigger_ovs }}
+###############################################################################
+{% if options.mlockall_disabled -%}
+OVS_CTL_OPTS='--no-mlockall'
+{% endif -%}

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -167,7 +167,7 @@ class TestUssuriOVNChassisCharm(Helper):
         self.assertEquals(self.target.services, [
             'ovn-host', 'neutron-ovn-metadata-agent'])
         self.assertDictEqual(self.target.restart_map, {
-            '/etc/default/openvswitch-switch': ['openvswitch-switch'],
+            '/etc/default/openvswitch-switch': [],
             '/etc/neutron/neutron_ovn_metadata_agent.ini': [
                 'neutron-ovn-metadata-agent'],
             '/etc/openvswitch/system-id.conf': [],
@@ -195,7 +195,7 @@ class TestDPDKOVNChassisCharm(Helper):
         self.assertEquals(self.target.packages, [
             'ovn-host', 'openvswitch-switch-dpdk'])
         self.assertDictEqual(self.target.restart_map, {
-            '/etc/default/openvswitch-switch': ['openvswitch-switch'],
+            '/etc/default/openvswitch-switch': [],
             '/etc/dpdk/interfaces': ['dpdk'],
             '/etc/openvswitch/system-id.conf': [],
         })
@@ -660,7 +660,7 @@ class TestSRIOVOVNChassisCharm(Helper):
         ])
         self.assertDictEqual(self.target.restart_map, {
             '/etc/sriov-netplan-shim/interfaces.yaml': [],
-            '/etc/default/openvswitch-switch': ['openvswitch-switch'],
+            '/etc/default/openvswitch-switch': [],
             '/etc/neutron/neutron.conf': ['neutron-sriov-agent'],
             '/etc/neutron/plugins/ml2/sriov_agent.ini': [
                 'neutron-sriov-agent'],
@@ -698,7 +698,7 @@ class TestHWOffloadChassisCharm(Helper):
         ])
         self.assertDictEqual(self.target.restart_map, {
             '/etc/sriov-netplan-shim/interfaces.yaml': [],
-            '/etc/default/openvswitch-switch': ['openvswitch-switch'],
+            '/etc/default/openvswitch-switch': [],
             '/etc/openvswitch/system-id.conf': [],
         })
         self.assertEquals(self.target.group, 'root')

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -439,6 +439,7 @@ class TestOVNChassisCharm(Helper):
         self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_key')
         self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_cert')
         self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_ca_cert')
+        self.patch_object(ovn_charm.ch_core.host, 'service_restart')
         self.patch_target('get_data_ip')
         self.get_data_ip.return_value = 'fake-data-ip'
         self.patch_target('get_ovs_hostname')
@@ -447,6 +448,7 @@ class TestOVNChassisCharm(Helper):
         self.check_if_paused.return_value = ('some', 'reason')
         self.target.configure_ovs('fake-sb-conn-str', True)
         self.run.assert_not_called()
+        self.service_restart.assert_not_called()
         self.check_if_paused.return_value = (None, None)
         self.target.configure_ovs('fake-sb-conn-str', False)
         self.run.assert_has_calls([
@@ -461,6 +463,7 @@ class TestOVNChassisCharm(Helper):
             mock.call('ovs-vsctl', 'set', 'open', '.',
                       'external-ids:ovn-remote=fake-sb-conn-str'),
         ])
+        self.service_restart.assert_not_called()
         self.run.reset_mock()
         self.target.enable_openstack = True
         self.patch_object(ovn_charm.ch_ovsdb, 'SimpleOVSDB')
@@ -485,6 +488,7 @@ class TestOVNChassisCharm(Helper):
                       '--', 'add', 'Open_vSwitch', '.', 'manager_options',
                       '@manager'),
         ])
+        assert self.service_restart.called
 
     def test_render_nrpe(self):
         self.patch_object(ovn_charm.nrpe, 'NRPE')

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -133,6 +133,7 @@ class TestOvnHandlers(test_utils.PatchHelper):
         self.patch_object(handlers.reactive, 'endpoint_from_flag')
         self.patch_object(handlers.charm, 'optional_interfaces')
         self.patch_object(handlers.reactive, 'set_flag')
+        self.patch_object(handlers.reactive, 'is_flag_set', return_value=True)
         ovsdb = mock.MagicMock()
         ovsdb.db_sb_connection_strs = [
             'ssl:192.0.2.11:6642',
@@ -142,7 +143,7 @@ class TestOvnHandlers(test_utils.PatchHelper):
         self.endpoint_from_flag.return_value = ovsdb
         handlers.configure_ovs()
         self.charm.configure_ovs.assert_called_once_with(
-            ','.join(ovsdb.db_sb_connection_strs))
+            ','.join(ovsdb.db_sb_connection_strs), True)
         self.charm.render_with_interfaces.assert_called_once_with(
             self.optional_interfaces((ovsdb,),
                                      'nova-compute.connected',


### PR DESCRIPTION
By default, mlockall() is enabled for ovs-vswitchd. This results in
locking all of ovs-vswitchd's process memory into physical RAM and
prevents paging. This enables network performance but can lead to
memory exhaustion in memory-constrained environments. To disable
mlockall(), the disable-mlockall charm config option can be set to
True. If unset, disable-mlockall charm config will result in
disabling mlockall if running in a container.

This patch also changes the ordering of config rendering to occur
before configure_ovs() and ensures that if disable-mlockall changes
that openvswitch-switch will be restarted prior to ovs configuration.

Closes-Bug: #1906280