### PR TITLE
Move OVNChassisCharm propoerties out of __init__

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -115,14 +115,22 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     python_version = 3
     enable_openstack = False
     bridges_key = 'bridge-interface-mappings'
+    # Services to be monitored by nrpe
+    nrpe_check_base_services = []
+    # Extra packages and services to be installed, managed and monitored if
+    # charm forms part of an Openstack Deployemnt
     openstack_packages = []
     openstack_services = []
     openstack_restart_map = {}
-    nrpe_check_base_services = []
     nrpe_check_openstack_services = []
 
     @property
     def nrpe_check_services(self):
+        """Full list of services to be monitored by nrpe.
+
+        :returns: List of services
+        :rtype: List[str]
+        """
         _check_services = self.nrpe_check_base_services[:]
         if self.enable_openstack:
             _check_services.extend(self.nrpe_check_openstack_services)
@@ -130,10 +138,20 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     @property
     def enable_openstack(self):
+        """Whether charm forms part of an OpenStack deployment.
+
+        :returns: Whether charm forms part of an OpenStack deployment
+        :rtype: boolean
+        """
         return reactive.is_flag_set('charm.ovn-chassis.enable-openstack')
 
     @property
     def packages(self):
+        """Full list of packages to be installed.
+
+        :returns: List of packages
+        :rtype: List[str]
+        """
         _packages = ['ovn-host']
         if self.options.enable_dpdk:
             _packages.extend(['openvswitch-switch-dpdk'])
@@ -159,6 +177,11 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     @property
     def group(self):
+        """Group that should own files
+
+        :returns: Group name
+        :rtype: str
+        """
         # When OpenStack support is enabled the various config files laid
         # out for Neutron agents need to have group ownership of 'neutron'
         # for the services to have access to them.
@@ -169,6 +192,11 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     @property
     def services(self):
+        """Full list of services to be managed..
+
+        :returns: List of services.
+        :rtype: List[str]
+        """
         _services = ['ovn-host']
         if self.enable_openstack:
             _services.extend(self.openstack_services)
@@ -176,6 +204,11 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     @property
     def restart_map(self):
+        """Which services should be notified when a file changes.
+
+        :returns: Restart map
+        :rtype: Dict[str, List[str]]
+        """
         # Note that we use the standard config render features of
         # charms.openstack to just copy this file in place hence no
         # service attached.
@@ -220,7 +253,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""
         super().__init__(**kwargs)
-        if reactive.is_flag_set('charm.ovn-chassis.enable-openstack'):
+        if self.enable_openstack:
             if self.options.enable_sriov:
                 if 'amqp' not in self.required_relations:
                     self.required_relations.append('amqp')

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -118,7 +118,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     # Services to be monitored by nrpe
     nrpe_check_base_services = []
     # Extra packages and services to be installed, managed and monitored if
-    # charm forms part of an Openstack Deployemnt
+    # charm forms part of an Openstack Deployment
     openstack_packages = []
     openstack_services = []
     openstack_restart_map = {}
@@ -192,7 +192,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
     @property
     def services(self):
-        """Full list of services to be managed..
+        """Full list of services to be managed.
 
         :returns: List of services.
         :rtype: List[str]

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -253,10 +253,9 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     def __init__(self, **kwargs):
         """Allow augmenting behaviour on external factors."""
         super().__init__(**kwargs)
-        if self.enable_openstack:
-            if self.options.enable_sriov:
-                if 'amqp' not in self.required_relations:
-                    self.required_relations.append('amqp')
+        if (self.enable_openstack and self.options.enable_sriov
+                and 'amqp' not in self.required_relations):
+            self.required_relations.append('amqp')
 
     def install(self):
         """Extend the default install method to handle update-alternatives.

--- a/tox.ini
+++ b/tox.ini
@@ -77,4 +77,4 @@ commands = {posargs}
 
 [flake8]
 # E402 ignore necessary for path append before sys module import in actions
-ignore = E402
+ignore = E402,E226,W503,W504

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -638,7 +638,7 @@ class TestSRIOVOVNChassisCharm(Helper):
             'enable-dpdk': False,
             'bridge-interface-mappings': 'br-ex:eth0',
             'ovn-bridge-mappings': 'physnet2:br-ex',
-        })
+        }, is_flag_set_return_value=True)
         self.enable_openstack.return_value = True
 
     def test__init__(self):
@@ -659,6 +659,9 @@ class TestSRIOVOVNChassisCharm(Helper):
                 'neutron-ovn-metadata-agent']
         })
         self.assertEquals(self.target.group, 'neutron')
+        self.assertEquals(
+            self.target.required_relations,
+            ['certificates', 'ovsdb', 'amqp'])
 
     def test_install(self):
         self.patch_target('configure_source')

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -85,15 +85,24 @@ class Helper(test_utils.PatchHelper):
             'enable-dpdk': False,
             'bridge-interface-mappings': 'br-ex:eth0'
         }
+        self.enable_openstack = mock.PropertyMock
+        self.enable_openstack.return_value = False
         if release and release == 'train':
             self.target = ovn_charm.BaseTrainOVNChassisCharm()
+            self.patch(
+                'charms.ovn_charm.BaseTrainOVNChassisCharm.enable_openstack',
+                new_callable=self.enable_openstack)
         else:
             self.target = ovn_charm.BaseUssuriOVNChassisCharm()
+            self.patch(
+                'charms.ovn_charm.BaseUssuriOVNChassisCharm.enable_openstack',
+                new_callable=self.enable_openstack)
         # remove the 'is_flag_set' patch so the tests can use it
         self._patches['is_flag_set'].stop()
         setattr(self, 'is_flag_set', None)
         del(self._patches['is_flag_set'])
         del(self._patches_start['is_flag_set'])
+
         self.patch('charmhelpers.contrib.openstack.context.DPDKDeviceContext',
                    name='DPDKDeviceContext')
         self.DPDKDeviceContext.return_value = lambda: {
@@ -122,7 +131,8 @@ class Helper(test_utils.PatchHelper):
 class TestTrainOVNChassisCharm(Helper):
 
     def setUp(self):
-        super().setUp(release='train', is_flag_set_return_value=True)
+        super().setUp(release='train')
+        self.enable_openstack.return_value = True
 
     def test_optional_openstack_metadata_train(self):
         self.assertEquals(self.target.packages, [
@@ -138,7 +148,8 @@ class TestTrainOVNChassisCharm(Helper):
 class TestUssuriOVNChassisCharm(Helper):
 
     def setUp(self):
-        super().setUp(is_flag_set_return_value=True)
+        super().setUp()
+        self.enable_openstack.return_value = True
 
     def test_optional_openstack_metadata_ussuri(self):
         self.assertEquals(self.target.packages, [
@@ -440,7 +451,7 @@ class TestOVNChassisCharm(Helper):
                       'external-ids:ovn-remote=fake-sb-conn-str'),
         ])
         self.run.reset_mock()
-        self.target.enable_openstack = True
+        self.enable_openstack.return_value = True
         self.patch_object(ovn_charm.ch_ovsdb, 'SimpleOVSDB')
         managers = mock.MagicMock()
         self.SimpleOVSDB.return_value = managers
@@ -627,7 +638,8 @@ class TestSRIOVOVNChassisCharm(Helper):
             'enable-dpdk': False,
             'bridge-interface-mappings': 'br-ex:eth0',
             'ovn-bridge-mappings': 'physnet2:br-ex',
-        }, is_flag_set_return_value=True)
+        })
+        self.enable_openstack.return_value = True
 
     def test__init__(self):
         self.assertEquals(self.target.packages, [

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -642,6 +642,7 @@ class TestSRIOVOVNChassisCharm(Helper):
         self.enable_openstack.return_value = True
 
     def test__init__(self):
+        self.maxDiff = None
         self.assertEquals(self.target.packages, [
             'ovn-host',
             'sriov-netplan-shim',


### PR DESCRIPTION
When the `ovn-chassis` charm is deployed with `new-units-paused=true`,
the `charm.ovn-chassis.enable-openstack` flag is not set because the
handler that sets that flag does not run when units are paused. When
the migration is complete the operator runs a resume on all the
`ovn-chassis` units. This resume in-turn runs a `config-changed` hook
from within the `resume` action. When the `config-changed` hook fires the
previously guarded handler now runs and executes the code that sets
the `charm.ovn-chassis.enable-openstack` state and then runs a
`charm_instance.install()` *1. However the charm instance that
`charm.provide_charm_instance()` provided is cached *2 from a previous
handler. When the first handler ran, which created an instance of the
class, `charm.ovn-chassis.enable-openstack` was not set and since the
list of packages, services and restart map is amended in the init
method depending on whether `charm.ovn-chassis.enable-openstack` flag
is set cached class does not include the metadata service in its
package,service or restart map objects. This change moves package,
service or restart maps to be properties that are evaluated when
accessed rather than at `__init__` time.


*1 https://github.com/openstack-charmers/charm-layer-ovn/blob/master/reactive/ovn_chassis_charm_handlers.py#L65
*2 https://github.com/openstack/charms.openstack/blob/master/charms_openstack/charm/core.py#L344

Closes-Bug: #1912471