### PR TITLE
Ensure disable-mlockall is handled at deploy time

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -283,6 +283,14 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
         super().install()
 
+        if not reactive.is_flag_set('charm.installed'):
+            # We need to render /etc/default/openvswitch-switch after the
+            # initial install and restart openvswitch-switch. This is done to
+            # ensure that when the disable-mlockall config option is unset,
+            # mlockall is disabled when running in a container.
+            self.render_configs(['/etc/default/openvswitch-switch'])
+            ch_core.host.service_restart('openvswitch-switch')
+
         if self.options.enable_dpdk:
             self.run('update-alternatives', '--set', 'ovs-vswitchd',
                      '/usr/lib/openvswitch-switch-dpdk/ovs-vswitchd-dpdk')

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -694,9 +694,17 @@ class TestSRIOVOVNChassisCharm(Helper):
         self.patch_target('configure_source')
         self.patch_target('run')
         self.patch_target('update_api_ports')
+        self.patch_target('render_configs')
+        self.patch_object(ovn_charm.ch_core.host, 'service_restart')
+        self.patch_object(ovn_charm.reactive, 'is_flag_set',
+                          return_value=False)
         self.target.install()
         self.configure_source.assert_called_once_with(
             'networking-tools-source')
+        self.render_configs.assert_called_once_with(
+            ['/etc/default/openvswitch-switch'])
+        self.service_restart.assert_called_once_with(
+            'openvswitch-switch')
 
 
 class TestHWOffloadChassisCharm(Helper):


### PR DESCRIPTION
The prior commit that enable disable-mlockall support only restarts
openvswitch-switch when the disable-mlockall config value is changed. It
didn't handle deploy-time restart of openvswitch-switch.

This patch ensures that /etc/default/openvswitch-swith is rendered and
openvswitch-switch is restarted directly after install. This ensures that
when the disable-mlockall config option is unset, mlockall actually gets
disabled when running in a container. See config.yaml description for more
details.

Related-Bug: #1906280