### PR TITLE
Avoid unnecessary restart of OVS on initial deploy

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -283,7 +283,8 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
 
         super().install()
 
-        if not reactive.is_flag_set('charm.installed'):
+        if (not reactive.is_flag_set('charm.installed') and
+                self.options.mlockall_disabled):
             # We need to render /etc/default/openvswitch-switch after the
             # initial install and restart openvswitch-switch. This is done to
             # ensure that when the disable-mlockall config option is unset,

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -698,6 +698,8 @@ class TestSRIOVOVNChassisCharm(Helper):
         self.patch_object(ovn_charm.ch_core.host, 'service_restart')
         self.patch_object(ovn_charm.reactive, 'is_flag_set',
                           return_value=False)
+        self.patch_object(ovn_charm.ch_core.hookenv, 'config')
+        self.config.return_value = None
         self.target.install()
         self.configure_source.assert_called_once_with(
             'networking-tools-source')


### PR DESCRIPTION
The commited fix for LP: #1906280 has guard rails to only restart
Open vSwitch on initial install.

However, this is not sufficient as the charm may be deployed to a
unit with a running Open vSwitch data plane as laid out in the OVS
to OVN migration guide [0].

Rework so that we only do the restart when necessary.

0: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html#migration-from-neutron-ml2-ovs-to-ml2-ovn
Related-Bug: #1906280