### PR TITLE
Fix rendering of SR-IOV interfaces file

### DIFF
--- a/templates/interfaces.yaml
+++ b/templates/interfaces.yaml
@@ -2,6 +2,6 @@ interfaces:
   {% for _, pcidnvfs in options.sriov_device.get_map.items() -%}
   {{ pcidnvfs.device.interface_name }}:
     match:
-      pciaddress: {{ pcidnvfs.device.pci_address }}
+      pciaddress: '{{ pcidnvfs.device.pci_address }}'
     num_vfs: {{ pcidnvfs.numvfs }}
   {% endfor -%}


### PR DESCRIPTION
Depending on which PCI address a network interface resolves to
the YAML produced may or may not deserialize into the correct
value.

Encapsulate the address in quotes so that YAML deserialization
always succeeds.