### PR TITLE
Fix missing init of SRIOV context for hw-offload

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -55,7 +55,8 @@ class OVNConfigurationAdapter(
             self._dpdk_device = self.OSContextObjectView(
                 os_context.DPDKDeviceContext(
                     bridges_key=self.charm_instance.bridges_key)())
-        if ch_core.hookenv.config('enable-sriov'):
+        if (ch_core.hookenv.config('enable-hardware-offload') or
+                ch_core.hookenv.config('enable-sriov')):
             self._sriov_device = os_context.SRIOVContext()
 
     @property

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -63,6 +63,21 @@ def disable_openstack():
 
 
 @reactive.when_none('charm.paused', 'is-update-status-hook')
+@reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
+               'config.changed.enable-hardware-offload')
+def ensure_networking_tools_installed():
+    """Ensure the networking tools are installed.
+
+    If the charm is used without OpenStack and hardware offload is enabled
+    post deploy the package may not be installed until we get here.
+    """
+    with charm.provide_charm_instance() as charm_instance:
+        charm_instance.install()
+        charm_instance.assess_status()
+        reactive.clear_flag('config.changed.enable-hardware-offload')
+
+
+@reactive.when_none('charm.paused', 'is-update-status-hook')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'nova-compute.connected')
 def enable_openstack():
     reactive.set_flag('charm.ovn-chassis.enable-openstack')

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -47,6 +47,9 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                 'enable_openstack': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                     'nova-compute.connected',),
+                'ensure_networking_tools_installed': (
+                    handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
+                    'config.changed.enable-hardware-offload',),
                 'configure_bridges': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                     'config.rendered',),
@@ -64,6 +67,9 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'is-update-status-hook',
                     'nova-compute.connected',),
                 'enable_openstack': ('charm.paused', 'is-update-status-hook'),
+                'ensure_networking_tools_installed': (
+                    'charm.paused',
+                    'is-update-status-hook'),
                 'configure_bridges': (
                     'charm.paused',
                     'is-update-status-hook'),


### PR DESCRIPTION
Commit ba9ca99193324c69d6a4e82f64786aea26096140 introduced a
regression that prohibits use of hw-offload due to not initializing
the SR-IOV context. Fix it.