### PR TITLE
Add setting pmd-cpu-mask via config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -198,6 +198,23 @@ options:
       NOTE: Values in this configuration option will only have effect for units
       that have a interface referenced in the `bridge-interface-mappings`
       configuration option.
+  pmd-cpu-set:
+    type: string
+    default:
+    description: |
+      Comma separated list of cpus used for DPDK datapath packet processing.
+      The range and caret operators are supported.
+
+      Example: 2,4,5-9,^7,16-23,^20,^22
+
+      If this option is not set, the pmd-cpu-mask field in the open_vswitch
+      table will be set to a default mask that is the next cpu of each NUMA
+      node following the dpdk-lcore-mask in order to avoid overlap.
+      .
+      Only used when DPDK is enabled.
+      NOTE: It is recommended to avoid overlap between datapath (pmd-cpu-mask)
+      and non-datapath (dpdk-lcore-mask) cpus. The charm will go into blocked
+      state if an overlap is detected.
   sriov-device-mappings:
     type: string
     default:


### PR DESCRIPTION
Review on gerrit with CI results: https://review.opendev.org/c/x/charm-ovn-chassis/+/784557

* config.yaml

Added pmd-cpu-set as a config option.

* lib/charms/ovn_charm.py:

Added the ability to set pmd-cpu-mask in the other_config record of the
open_vswitch table. When an overlap is detected with dpdk-lcore-mask,
charm is set to blocked state with a message asking to fix the overlap.

Related-Bug: #1905416