### PR TITLE
Add support for deferred support to OVN charms.

### DIFF
--- a/actions/os_deferred_event_actions.py
+++ b/actions/os_deferred_event_actions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2016 Canonical Ltd
+# Copyright 2021 Canonical Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/actions/os_deferred_event_actions.py
+++ b/actions/os_deferred_event_actions.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2016 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+# Load modules from $CHARM_DIR/lib
+sys.path.append('lib')
+
+from charms.layer import basic
+basic.bootstrap_charm_deps()
+
+import charmhelpers.contrib.openstack.deferred_events as deferred_events
+import charmhelpers.contrib.openstack.utils as os_utils
+import charmhelpers.core.hookenv as hookenv
+import charms_openstack.bus
+import charms_openstack.charm
+import charms.reactive as reactive
+
+charms_openstack.bus.discover()
+
+
+def restart_services(args):
+    """Restart services.
+
+    :param args: Unused
+    :type args: List[str]
+    """
+    deferred_only = hookenv.action_get("deferred-only")
+    services = hookenv.action_get("services").split()
+    # Check input
+    if deferred_only and services:
+        hookenv.action_fail("Cannot set deferred-only and services")
+        return
+    if not (deferred_only or services):
+        hookenv.action_fail("Please specify deferred-only or services")
+        return
+    if deferred_only:
+        os_utils.restart_services_action(deferred_only=True)
+    else:
+        os_utils.restart_services_action(services=services)
+    with charms_openstack.charm.provide_charm_instance() as charm_instance:
+        charm_instance._assess_status()
+
+
+def show_deferred_events(args):
+    """Show the deferred events.
+
+    :param args: Unused
+    :type args: List[str]
+    """
+    os_utils.show_deferred_events_action_helper()
+
+
+def run_deferred_hooks(args):
+    """Run deferred hooks.
+
+    :param args: Unused
+    :type args: List[str]
+    """
+    deferred_methods = deferred_events.get_deferred_hooks()
+    ovsdb = reactive.endpoint_from_flag('ovsdb.available')
+    with charms_openstack.charm.provide_charm_instance() as charm_instance:
+        if ('install' in deferred_methods or
+                'configure_ovs' in deferred_methods):
+            charm_instance.install(check_deferred_events=False)
+        if 'configure_ovs' in deferred_methods:
+            charm_instance.render_with_interfaces(
+                charms_openstack.charm.optional_interfaces(
+                    (ovsdb,),
+                    'nova-compute.connected',
+                    'amqp.connected'))
+            charm_instance.configure_ovs(
+                ','.join(ovsdb.db_sb_connection_strs),
+                reactive.is_flag_set('config.changed.disable-mlockall'),
+                check_deferred_events=False)
+        charm_instance._assess_status()
+
+
+# Actions to function mapping, to allow for illegal python action names that
+# can map to a python function.
+ACTIONS = {
+    "restart-services": restart_services,
+    "show-deferred-events": show_deferred_events,
+    "run-deferred-hooks": run_deferred_hooks
+}
+
+
+def main(args):
+    hookenv._run_atstart()
+    action_name = os.path.basename(args[0])
+    try:
+        action = ACTIONS[action_name]
+    except KeyError:
+        return "Action %s undefined" % action_name
+    else:
+        try:
+            action(args)
+        except Exception as e:
+            hookenv.action_fail(str(e))
+    hookenv._run_atexit()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -23,12 +23,97 @@ import charmhelpers.contrib.charmsupport.nrpe as nrpe
 import charmhelpers.contrib.openstack.context as os_context
 import charmhelpers.contrib.network.ovs as ch_ovs
 import charmhelpers.contrib.network.ovs.ovsdb as ch_ovsdb
+import charmhelpers.contrib.openstack.deferred_events as deferred_events
 
 import charms_openstack.adapters
 import charms_openstack.charm
 
 
 CERT_RELATION = 'certificates'
+_DEFERABLE_SVC_LIST = ['openvswitch-switch', 'ovn-controller', 'ovn-host',
+                       'ovs-vswitchd', 'ovsdb-server']
+
+
+class DeferredEventMixin():
+    """Mixin to add to charm class to add support for deferred events."""
+
+    @property
+    def deferable_services(self):
+        """Services which should be stopped from restarting."""
+        svcs = self.services[:]
+        svcs.extend(_DEFERABLE_SVC_LIST)
+        return list(set(svcs))
+
+    def configure_deferred_restarts(self):
+        """Install deferred event files and policies."""
+        if 'enable-auto-restarts' in ch_core.hookenv.config().keys():
+            deferred_events.configure_deferred_restarts(
+                self.deferable_services)
+            # Reactive charms execute perm missing.
+            os.chmod(
+                '/var/lib/charm/{}/policy-rc.d'.format(
+                    ch_core.hookenv.service_name()),
+                0o755)
+
+    def custom_assess_status_check(self):
+        """Report deferred events in charm status message."""
+        state = None
+        message = None
+        deferred_events.check_restart_timestamps()
+        events = collections.defaultdict(set)
+        for e in deferred_events.get_deferred_events():
+            events[e.action].add(e.service)
+        for action, svcs in events.items():
+            svc_msg = "Services queued for {}: {}".format(
+                action, ', '.join(sorted(svcs)))
+            state = 'active'
+            if message:
+                message = "{}. {}".format(message, svc_msg)
+            else:
+                message = svc_msg
+        deferred_hooks = deferred_events.get_deferred_hooks()
+        if deferred_hooks:
+            state = 'active'
+            svc_msg = "Hooks skipped due to disabled auto restarts: {}".format(
+                ', '.join(sorted(deferred_hooks)))
+            if message:
+                message = "{}. {}".format(message, svc_msg)
+            else:
+                message = svc_msg
+        return state, message
+
+    def configure_ovs(self, sb_conn, mlockall_changed,
+                      check_deferred_events=True):
+        """Run configure_ovs if permitted.
+
+        :param sb_conn: Comma separated string of OVSDB connection methods.
+        :type sb_conn: str
+        :param mlockall_changed: Whether the mlockall param has changed.
+        :type mlockall_changed: bool
+        :param check_deferred_events: Whether to check if restarts are
+                                      permitted before running hook.
+        :type check_deferred_events: bool
+        """
+        if ((not check_deferred_events) or
+                deferred_events.is_restart_permitted()):
+            deferred_events.clear_deferred_hook('configure_ovs')
+            super().configure_ovs(sb_conn, mlockall_changed)
+        else:
+            deferred_events.set_deferred_hook('configure_ovs')
+
+    def install(self, check_deferred_events=True):
+        """Run install if permitted.
+
+        :param check_deferred_events: Whether to check if restarts are
+                                      permitted before running hook.
+        :type check_deferred_events: bool
+        """
+        if ((not check_deferred_events) or
+                deferred_events.is_restart_permitted()):
+            deferred_events.clear_deferred_hook('install')
+            super().install()
+        else:
+            deferred_events.set_deferred_hook('install')
 
 
 class OVNConfigurationAdapter(

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -39,13 +39,33 @@ class DeferredEventMixin():
 
     @property
     def deferable_services(self):
-        """Services which should be stopped from restarting."""
+        """Services which should be stopped from restarting.
+
+        All services from self.services are deferable. But the charm may
+        install a package which install a service that the charm does not add
+        to its restart_map. In that case it will be missing from
+        self.services. However one of the jobs of deferred events is to ensure
+        that packages updates outside of charms also do not restart services.
+        To ensure there is a complete list take the services from self.services
+        and also add in a known list of networking services.
+
+        NOTE: It does not matter if one of the services in the list is not
+        installed on the system.
+
+        """
         svcs = self.services[:]
         svcs.extend(_DEFERABLE_SVC_LIST)
         return list(set(svcs))
 
     def configure_deferred_restarts(self):
-        """Install deferred event files and policies."""
+        """Install deferred event files and policies.
+
+        Check that the charm supports deferred events by checking for the
+        presence of the 'enable-auto-restarts' config option. If it is present
+        then install the supporting files and directories, however,
+        configure_deferred_restarts only enables deferred events if
+        'enable-auto-restarts' is True.
+        """
         if 'enable-auto-restarts' in ch_core.hookenv.config().keys():
             deferred_events.configure_deferred_restarts(
                 self.deferable_services)

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -33,9 +33,12 @@ class _fake_decorator(object):
         return f
 
 
+sys.modules['charms.layer'] = mock.MagicMock()
 sys.modules['charmhelpers.contrib.network.ovs'] = mock.MagicMock()
 sys.modules['charmhelpers.contrib.network.ovs.ovsdb'] = mock.MagicMock()
 sys.modules['charmhelpers.contrib.charmsupport.nrpe'] = mock.MagicMock()
+sys.modules[
+    'charmhelpers.contrib.openstack.deferred_events'] = mock.MagicMock()
 charms.leadership = mock.MagicMock()
 sys.modules['charms.leadership'] = charms.leadership
 charms.reactive = mock.MagicMock()

--- a/unit_tests/test_actions_os_deferred_event_actions.py
+++ b/unit_tests/test_actions_os_deferred_event_actions.py
@@ -1,0 +1,140 @@
+# Copyright 2021 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest.mock as mock
+import actions.os_deferred_event_actions as os_deferred_event_actions
+import charms_openstack.test_utils as test_utils
+
+
+class TestOSDeferredEventActions(test_utils.PatchHelper):
+
+    def setUp(self):
+        super().setUp()
+        self.patch_object(os_deferred_event_actions.hookenv, 'action_get')
+        self.action_config = {}
+        self.action_get.side_effect = lambda x: self.action_config.get(x)
+        self.patch_object(os_deferred_event_actions.hookenv, 'action_fail')
+
+        self.patch_object(
+            os_deferred_event_actions.charms_openstack.charm,
+            'provide_charm_instance')
+        self.charm_instance = mock.MagicMock()
+        self.provide_charm_instance.return_value.__enter__.return_value = \
+            self.charm_instance
+
+    def test_restart_services(self):
+        self.patch_object(
+            os_deferred_event_actions.os_utils,
+            'restart_services_action')
+
+        self.action_config = {
+            'deferred-only': True,
+            'services': ''}
+        os_deferred_event_actions.restart_services(['restart-services'])
+        self.charm_instance._assess_status.assert_called_once_with()
+        self.restart_services_action.assert_called_once_with(
+            deferred_only=True)
+
+        self.charm_instance.reset_mock()
+        self.restart_services_action.reset_mock()
+
+        self.action_config = {
+            'deferred-only': False,
+            'services': 'svcA svcB'}
+        os_deferred_event_actions.restart_services(['restart-services'])
+        self.charm_instance._assess_status.assert_called_once_with()
+        self.restart_services_action.assert_called_once_with(
+            services=['svcA', 'svcB'])
+
+        self.charm_instance.reset_mock()
+        self.restart_services_action.reset_mock()
+
+        self.action_config = {
+            'deferred-only': True,
+            'services': 'svcA svcB'}
+        os_deferred_event_actions.restart_services(['restart-services'])
+        self.action_fail.assert_called_once_with(
+            'Cannot set deferred-only and services')
+
+        self.charm_instance.reset_mock()
+        self.restart_services_action.reset_mock()
+        self.action_fail.reset_mock()
+
+        self.action_config = {
+            'deferred-only': False,
+            'services': ''}
+        os_deferred_event_actions.restart_services(['restart-services'])
+        self.action_fail.assert_called_once_with(
+            'Please specify deferred-only or services')
+
+    def test_show_deferred_events(self):
+        self.patch_object(
+            os_deferred_event_actions.os_utils,
+            'show_deferred_events_action_helper')
+        os_deferred_event_actions.show_deferred_events(
+            ['show-deferred-events'])
+        self.show_deferred_events_action_helper.assert_called_once_with()
+
+    def test_run_deferred_hooks(self):
+        self.patch_object(
+            os_deferred_event_actions.deferred_events,
+            'get_deferred_hooks')
+        self.patch_object(
+            os_deferred_event_actions.reactive,
+            'endpoint_from_flag')
+        self.patch_object(
+            os_deferred_event_actions.reactive,
+            'is_flag_set')
+        self.patch_object(
+            os_deferred_event_actions.charms_openstack.charm,
+            'optional_interfaces')
+        interfaces_mock = mock.MagicMock()
+        self.optional_interfaces.return_value = interfaces_mock
+        self.is_flag_set.return_value = True
+        ovsdb_available = mock.MagicMock()
+        ovsdb_available.db_sb_connection_strs = ['constrA', 'connstrB']
+        self.endpoint_from_flag.return_value = ovsdb_available
+
+        self.get_deferred_hooks.return_value = ['install']
+        os_deferred_event_actions.run_deferred_hooks(['run-deferred-hooks'])
+        self.charm_instance.install.assert_called_once_with(
+            check_deferred_events=False)
+        self.assertFalse(self.charm_instance.configure_ovs.called)
+        self.assertFalse(
+            self.charm_instance.render_with_interfaces.called)
+        self.charm_instance._assess_status.assert_called_once_with()
+
+        self.charm_instance.reset_mock()
+
+        self.get_deferred_hooks.return_value = ['install', 'configure_ovs']
+        os_deferred_event_actions.run_deferred_hooks(['run-deferred-hooks'])
+        self.charm_instance.install.assert_called_once_with(
+            check_deferred_events=False)
+        self.charm_instance.render_with_interfaces.assert_called_once_with(
+            interfaces_mock)
+        self.charm_instance.configure_ovs.assert_called_once_with(
+            'constrA,connstrB',
+            True,
+            check_deferred_events=False)
+        self.charm_instance._assess_status.assert_called_once_with()
+
+        self.charm_instance.reset_mock()
+
+        self.get_deferred_hooks.return_value = []
+        os_deferred_event_actions.run_deferred_hooks(['run-deferred-hooks'])
+        self.assertFalse(self.charm_instance.install.configure_ovs.called)
+        self.assertFalse(self.charm_instance.configure_ovs.called)
+        self.assertFalse(self.charm_instance.render_with_interfaces.called)
+        self.charm_instance._assess_status.assert_called_once_with()


### PR DESCRIPTION
This adds optional support for deferred events to ovn charms.
For an OVN charm to enable deferred event support it needs to
add the DeferredEventMixin class to the charm class and also
add the action files. Without doing these this change does not
affect a charm.