### PR TITLE
Add ovs-record-hostname to deferred service list

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -31,7 +31,7 @@ import charms_openstack.charm
 
 CERT_RELATION = 'certificates'
 _DEFERABLE_SVC_LIST = ['openvswitch-switch', 'ovn-controller', 'ovn-host',
-                       'ovs-vswitchd', 'ovsdb-server']
+                       'ovs-vswitchd', 'ovsdb-server', 'ovs-record-hostname']
 
 
 class DeferredEventMixin():

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -50,6 +50,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
                 'mysvc',
                 'ovs-vswitchd',
                 'ovsdb-server',
+                'ovs-record-hostname',
                 'ovn-controller'])
 
     def test_configure_deferred_restarts(self):
@@ -73,6 +74,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
                 'mysvc',
                 'ovs-vswitchd',
                 'ovsdb-server',
+                'ovs-record-hostname',
                 'ovn-controller'])
         self.chmod.assert_called_once_with(
             '/var/lib/charm/myapp/policy-rc.d',


### PR DESCRIPTION
Block restarts of ovs-record-hostname if restarts are not
permitted as it in turn restarts ovs services.