### PR TITLE
Initially run hooks when deferred restarts enabled

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -114,7 +114,9 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
-        if ((not check_deferred_events) or
+        changed = reactive.flags.is_flag_set(
+            'config.changed.enable-auto-restarts')
+        if ((not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('configure_ovs')
             super().configure_ovs(sb_conn, mlockall_changed)
@@ -128,7 +130,9 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
-        if ((not check_deferred_events) or
+        changed = reactive.flags.is_flag_set(
+            'config.changed.enable-auto-restarts')
+        if ((not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('install')
             super().install()

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -116,6 +116,9 @@ class DeferredEventMixin():
         """
         changed = reactive.flags.is_flag_set(
             'config.changed.enable-auto-restarts')
+        # Run method if enable-auto-restarts has changed, irrespective of what
+        # it was changed to. This ensure that this method is not immediately
+        # deferred when enable-auto-restarts is initially set to False.
         if ((not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('configure_ovs')
@@ -132,6 +135,9 @@ class DeferredEventMixin():
         """
         changed = reactive.flags.is_flag_set(
             'config.changed.enable-auto-restarts')
+        # Run method if enable-auto-restarts has changed, irrespective of what
+        # it was changed to. This ensure that this method is not immediately
+        # deferred when enable-auto-restarts is initially set to False.
         if ((not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('install')


### PR DESCRIPTION
Run hooks normally when deferred restarts are first enabled. Closes LP bug [1923647](https://bugs.launchpad.net/charm-ovn-chassis/+bug/1923647)

Tested here: https://paste.ubuntu.com/p/tv97Xk2yZB/