### PR TITLE
Deferred hook actions inline with classic charms

### DIFF
--- a/actions/os_deferred_event_actions.py
+++ b/actions/os_deferred_event_actions.py
@@ -93,6 +93,8 @@ def run_deferred_hooks(args):
     :type args: List[str]
     """
     _run_deferred_hooks()
+    # Hooks may trigger services to need restarting so restart any services
+    # marked as needing it now.
     os_utils.restart_services_action(deferred_only=True)
     with charms_openstack.charm.provide_charm_instance() as charm_instance:
         charm_instance._assess_status()


### PR DESCRIPTION
Bring the deferred hook actions inline with classic charms.

1) Stop ignoring the 'run-hooks' option when running
   'restart-services' action.

2) Make sure any services that need restarting are restarted after
   running the 'run-deferred-hooks' action.

Closes-Bug: 1925315