### PR TITLE
Add prefer-chassis-as-gw configuration option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -241,8 +241,9 @@ options:
     type: boolean
     default: false
     description: |
-      Prefer units of the named application in CMS scheduling of HA chassis
-      groups aka. gateways.
+      Prefer units of this application in CMS (Cloud Management System)
+      scheduling of HA chassis groups (aka. gateways) over units of other OVN
+      chassis applications present in this deployment.
       .
       By default the CMS will schedule HA chassis groups across all chassis
       with bridge- and bridge interface mappings configured.
@@ -254,6 +255,9 @@ options:
       NOTE: If none of the OVN chassis named applications in the deployment
       have this option enabled, the CMS will fall back to schedule gateways to
       chassis with bridge- and bridge interface mapping configured.
+      .
+      NOTE: It is also possible to enable this option on several OVN chassis
+      applications at the same time, e.g. on 2 out of 3.
   nagios_context:
     default: "juju"
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -237,6 +237,23 @@ options:
       integration bridge on the hypervisor and during a migration the operator
       may want to shut down and clean up after the ML2 OVS components before
       the `ovn-controller` takes over and reprograms the bridge flow rules.
+  prefer-chassis-as-gw:
+    type: boolean
+    default: false
+    description: |
+      Prefer units of the named application in CMS scheduling of HA chassis
+      groups aka. gateways.
+      .
+      By default the CMS will schedule HA chassis groups across all chassis
+      with bridge- and bridge interface mappings configured.
+      .
+      This configuration option would allow you to influence where gateways are
+      scheduled when all units have equal bridge- and bridge interface mapping
+      configuration.
+      .
+      NOTE: If none of the OVN chassis named applications in the deployment
+      have this option enabled, the CMS will fall back to schedule gateways to
+      chassis with bridge- and bridge interface mapping configured.
   nagios_context:
     default: "juju"
     type: string

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -856,13 +856,15 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         opvs = ch_ovsdb.SimpleOVSDB('ovs-vsctl').open_vswitch
         if ovn_br_map_str:
             opvs.set('.', 'external_ids:ovn-bridge-mappings', ovn_br_map_str)
-            # NOTE(fnordahl): Workaround for LP: #1848757
-            opvs.set('.', 'external_ids:ovn-cms-options',
-                     'enable-chassis-as-gw')
         else:
             opvs.remove('.', 'external_ids', 'ovn-bridge-mappings')
-            # NOTE(fnordahl): Workaround for LP: #1848757
-            opvs.remove('.', 'external_ids', 'ovn-cms-options')
+
+        if self.options.prefer_chassis_as_gw:
+            opvs.set(
+                '.', 'external_ids:ovn-cms-options', 'enable-chassis-as-gw')
+        else:
+            opvs.remove(
+                '.', 'external_ids', 'ovn-cms-options=enable-chassis-as-gw')
 
     def render_nrpe(self):
         """Configure Nagios NRPE checks."""

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -551,10 +551,8 @@ class TestDPDKOVNChassisCharm(Helper):
             mock.call('.', 'external_ids:ovn-bridge-mappings',
                       'other:br-data,provider:br-ex'),
         ], any_order=True)
-        ovsdb.open_vswitch.remove.assert_has_calls([
-            mock.call('.', 'external_ids',
-                      'ovn-cms-options=enable-chassis-as-gw')
-        ], any_order=True)
+        ovsdb.open_vswitch.remove.assert_called_once_with(
+            '.', 'external_ids', 'ovn-cms-options=enable-chassis-as-gw')
 
 
 class TestOVNChassisCharm(Helper):

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -547,10 +547,9 @@ class TestDPDKOVNChassisCharm(Helper):
                 'external-ids': {'charm-ovn-chassis': 'br-ex'}},
             linkup=False, promisc=None, portdata={
                 'external-ids': {'charm-ovn-chassis': 'br-ex'}}),
-        ovsdb.open_vswitch.set.assert_has_calls([
-            mock.call('.', 'external_ids:ovn-bridge-mappings',
-                      'other:br-data,provider:br-ex'),
-        ], any_order=True)
+        ovsdb.open_vswitch.set.assert_called_once_with(
+            '.', 'external_ids:ovn-bridge-mappings',
+            'other:br-data,provider:br-ex')
         ovsdb.open_vswitch.remove.assert_called_once_with(
             '.', 'external_ids', 'ovn-cms-options=enable-chassis-as-gw')
 

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -322,7 +322,8 @@ class Helper(test_utils.PatchHelper):
                 'enable-hardware-offload': False,
                 'enable-sriov': False,
                 'enable-dpdk': False,
-                'bridge-interface-mappings': 'br-ex:eth0'
+                'bridge-interface-mappings': 'br-ex:eth0',
+                'prefer-chassis-as-gw': False,
             }
             if x:
                 return cfg.get(x)
@@ -424,6 +425,7 @@ class TestDPDKOVNChassisCharm(Helper):
             'bridge-interface-mappings': 'br-ex:eth0 br-data:dpdk-bond0',
             'ovn-bridge-mappings': (
                 'provider:br-ex other:br-data'),
+            'prefer-chassis-as-gw': False,
         })
 
     def test__init__(self):
@@ -548,8 +550,10 @@ class TestDPDKOVNChassisCharm(Helper):
         ovsdb.open_vswitch.set.assert_has_calls([
             mock.call('.', 'external_ids:ovn-bridge-mappings',
                       'other:br-data,provider:br-ex'),
-            mock.call('.', 'external_ids:ovn-cms-options',
-                      'enable-chassis-as-gw'),
+        ], any_order=True)
+        ovsdb.open_vswitch.remove.assert_has_calls([
+            mock.call('.', 'external_ids',
+                      'ovn-cms-options=enable-chassis-as-gw')
         ], any_order=True)
 
 
@@ -564,6 +568,7 @@ class TestOVNChassisCharm(Helper):
                 'br-provider:00:01:02:03:04:05 br-other:eth5'),
             'ovn-bridge-mappings': (
                 'provider:br-provider other:br-other'),
+            'prefer-chassis-as-gw': True,
         })
 
     def test_optional_openstack_metadata(self):


### PR DESCRIPTION
By default the CMS will schedule HA chassis groups across all
chassis with bridge- and bridge interface mappings configured.

This configuration option would allow you to influence where
gateways are scheduled when all units have equal bridge- and
bridge interface mapping configuration.

Closes-Bug: #1908377
Closes-Bug: #1934678
Related-Bug: #1848757