### PR TITLE
Block ovn-chassis units with bad config

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -485,7 +485,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         """
 
         if not self.valid_config:
-            message = ('Wrong format. '
+            message = ('Wrong format for bridge-interface-mappings. '
                        'Expected format is space-delimited list of '
                        'key-value pairs. Ex: "br-internet:00:00:5e:00:00:42 '
                        'br-provider:enp3s0f0"')

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -474,16 +474,15 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             os.path.join(ch_core.hookenv.charm_dir(), 'hooks/config-changed'),
         )
 
-    def check_mandatory_config(self):
-        """Check that all mandatory config has been set and if has valid config.
+    def custom_assess_status_last_check(self):
+        """Check if has valid bridge config and set to blocked if is invalid.
 
         Returns (None, None) if the interfaces are okay, or a status, message
-        if any of the config is missing or invalid.
+        if the config is invalid.
 
         :returns status & message info
         :rtype: (status, message) or (None, None)
         """
-        status, message = super().check_mandatory_config()
 
         if not self.valid_config:
             message = ('Wrong format. '
@@ -491,9 +490,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                        'key-value pairs. Ex: "br-internet:00:00:5e:00:00:42 '
                        'br-provider:enp3s0f0"')
             return 'blocked', message
-
-        if status:
-            return status, message
 
         return None, None
 
@@ -788,7 +784,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             )
             self.valid_config = True
 
-        except os_context.BridgesKeyException:
+        except ValueError:
             self.valid_config = False
             return
 

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -861,15 +861,15 @@ class TestOVNChassisCharm(Helper):
         self.BridgePortInterfaceMap.side_effect = ValueError()
         self.patch_target('check_if_paused')
         self.check_if_paused.return_value = (None, None)
-        self.assertEqual( self.target.valid_config, True)
+        self.assertEqual(self.target.valid_config, True)
         self.target.configure_bridges()
         self.BridgePortInterfaceMap.assert_called_once_with(
             bridges_key='bridge-interface-mappings')
-        self.assertEqual( self.target.valid_config, False)
+        self.assertEqual(self.target.valid_config, False)
 
     def test_custom_assess_status_last_check(self):
         self.target.valid_config = False
-        message = ('Wrong format. '
+        message = ('Wrong format for bridge-interface-mappings. '
                    'Expected format is space-delimited list of '
                    'key-value pairs. Ex: "br-internet:00:00:5e:00:00:42 '
                    'br-provider:enp3s0f0"')


### PR DESCRIPTION
In order to fix the LP bug#1919481 [0] it was added a try
and except to intanciate the object BridgePortInterfaceMap.
If the config is wrong, it changes the attribute valid_config
to false and this will block the units in the check_mandatory_config
method.

[0] https://bugs.launchpad.net/charm-ovn-chassis/+bug/1919481