### PR TITLE
Allow additional dpdk runtime libraries to be installed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -124,6 +124,21 @@ options:
         uio_pci_generic
       .
       Only used when DPDK is enabled.
+  dpdk-runtime-libraries:
+    type: string
+    default:
+    description: |
+      Space delimited list of additional DPDK runtime libraries that should
+      be installed when DPDK is enabled.
+      .
+      By default, only the runtime libraries that are recommended with the
+      dpdk libraries are installed. Environments that need additional libraries
+      installed should include those library packages. For example, to enable
+      the pmd-bnx2x runtime library specify the name of the software package
+      `librte-pmd-bnx2x20.0`. To enable the pmd-bnx2x and the pmd-ice runtime
+      libraries, specify the value as `librte-pmd-bnx2x20.0 librte-pmd-ice20.0`.
+      .
+      Only used when DPDK is enabled.
   enable-hardware-offload:
     type: boolean
     default: false

--- a/config.yaml
+++ b/config.yaml
@@ -133,10 +133,11 @@ options:
       .
       By default, only the runtime libraries that are recommended with the
       dpdk libraries are installed. Environments that need additional libraries
-      installed should include those library packages. For example, to enable
-      the pmd-bnx2x runtime library specify the name of the software package
-      `librte-pmd-bnx2x20.0`. To enable the pmd-bnx2x and the pmd-ice runtime
-      libraries, specify the value as `librte-pmd-bnx2x20.0 librte-pmd-ice20.0`.
+      installed should include those library packages. The runtime libraries can
+      be defined either by the full package name (e.g. librte-pmd-bnx2x20.0)
+      or by the simple name (e.g. bnx2x). When providing the simple name, a
+      search is done of the apt-cache for a name matching `librte-*<name>*`
+      for installation and will install all matching packages that are found.
       .
       Only used when DPDK is enabled.
   enable-hardware-offload:

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -301,6 +301,21 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         return reactive.is_flag_set('charm.ovn-chassis.enable-openstack')
 
     @property
+    def additional_dpdk_libraries(self):
+        """A list of additional runtime libraries to be installed for dpdk.
+
+        :returns: list of additional packages to install
+        :rtype: List[str]
+        """
+        if self.options.enable_dpdk and self.options.dpdk_runtime_libraries:
+            # dpdk_runtime_libraries is a space delimited list of strings.
+            # some options are disabled by passing 'None' so filter out a
+            # specifying of a 'None' value
+            return list(filter(lambda x: x and x.lower() != 'none',
+                               self.options.dpdk_runtime_libraries.split()))
+        return []
+
+    @property
     def packages(self):
         """Full list of packages to be installed.
 
@@ -310,6 +325,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         _packages = ['ovn-host']
         if self.options.enable_dpdk:
             _packages.extend(['openvswitch-switch-dpdk'])
+            _packages.extend(self.additional_dpdk_libraries)
         if self.options.enable_hardware_offload or self.options.enable_sriov:
             # The ``sriov-netplan-shim`` package does boot-time
             # configuration of Virtual Functions (VFs) in the system.

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -442,6 +442,27 @@ class TestWallabyOVNChassisCharm(Helper):
             'neutron-ovn-metadata-agent'])
 
 
+class TestDPDKOVNChassisCharmExtraLibs(Helper):
+
+    def setUp(self):
+        super().setUp(config={
+            'enable-hardware-offload': False,
+            'enable-sriov': False,
+            'enable-dpdk': True,
+            'dpdk-bond-mappings': ('dpdk-bond0:a0:36:9f:dd:37:a4 '
+                                   'dpdk-bond0:a0:36:9f:dd:3e:9c'),
+            'bridge-interface-mappings': 'br-ex:eth0 br-data:dpdk-bond0',
+            'ovn-bridge-mappings': (
+                'provider:br-ex other:br-data'),
+            'prefer-chassis-as-gw': False,
+            'dpdk-runtime-libraries': 'librte-pmd-hinic20.0 None',
+        })
+
+    def test__init__(self):
+        self.assertEquals(self.target.packages, [
+            'ovn-host', 'openvswitch-switch-dpdk', 'librte-pmd-hinic20.0'])
+
+
 class TestDPDKOVNChassisCharm(Helper):
 
     def setUp(self):
@@ -455,6 +476,7 @@ class TestDPDKOVNChassisCharm(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-ex other:br-data'),
             'prefer-chassis-as-gw': False,
+            'dpdk-runtime-libraries': '',
         })
 
     def test__init__(self):

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -546,6 +546,77 @@ class TestDPDKOVNChassisCharmExtraLibs(Helper):
             'librte-net-mlx5-21'])
         self.run.assert_not_called()
 
+    def test_none_package(self):
+        self.local_config['dpdk-runtime-libraries'] = 'None'
+        target = ovn_charm.BaseUssuriOVNChassisCharm()
+        self.assertEquals(target.additional_dpdk_libraries, [])
+        self.run.assert_not_called()
+
+    def test_multiple_packages(self):
+        process1 = mock.Mock()
+        process1.stdout = textwrap.dedent(
+        """
+        librte-net-hinic21:
+          Installed: 20.11.3-0ubuntu0.21.04.2
+          Candidate: 20.11.3-0ubuntu0.21.04.2
+          Version table:
+         *** 20.11.3-0ubuntu0.21.04.2 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute-updates/universe amd64 Packages
+                100 /var/lib/dpkg/status
+             20.11.1-1 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute/universe amd64 Packages
+        """  # noqa
+        )
+        process2 = mock.Mock()
+        process2.stdout = textwrap.dedent(
+        """
+        librte-net-mlx5-21:
+          Installed: 20.11.3-0ubuntu0.21.04.2
+          Candidate: 20.11.3-0ubuntu0.21.04.2
+          Version table:
+         *** 20.11.3-0ubuntu0.21.04.2 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute-updates/main amd64 Packages
+                100 /var/lib/dpkg/status
+             20.11.1-1 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute/main amd64 Packages
+        librte-regex-mlx5-21:
+          Installed: 20.11.3-0ubuntu0.21.04.2
+          Candidate: 20.11.3-0ubuntu0.21.04.2
+          Version table:
+         *** 20.11.3-0ubuntu0.21.04.2 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute-updates/universe amd64 Packages
+                100 /var/lib/dpkg/status
+             20.11.1-1 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute/universe amd64 Packages
+        librte-common-mlx5-21:
+          Installed: 20.11.3-0ubuntu0.21.04.2
+          Candidate: 20.11.3-0ubuntu0.21.04.2
+          Version table:
+         *** 20.11.3-0ubuntu0.21.04.2 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute-updates/main amd64 Packages
+                100 /var/lib/dpkg/status
+             20.11.1-1 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute/main amd64 Packages
+        librte-vdpa-mlx5-21:
+          Installed: 20.11.3-0ubuntu0.21.04.2
+          Candidate: 20.11.3-0ubuntu0.21.04.2
+          Version table:
+         *** 20.11.3-0ubuntu0.21.04.2 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute-updates/universe amd64 Packages
+                100 /var/lib/dpkg/status
+             20.11.1-1 500
+                500 http://us.archive.ubuntu.com/ubuntu hirsute/universe amd64 Packages
+        """  # noqa
+        )
+
+        self.run.side_effect = [process1, process2]
+
+        self.local_config['dpdk-runtime-libraries'] = 'hinic mlx'
+        target = ovn_charm.BaseUssuriOVNChassisCharm()
+        self.assertEquals(target.additional_dpdk_libraries, [
+            'librte-net-hinic21', 'librte-net-mlx5-21', 'librte-regex-mlx5-21',
+            'librte-common-mlx5-21', 'librte-vdpa-mlx5-21'])
+
     def test_package_not_found(self):
         # Missing packages don't have output via this command
         self.called_process.stdout = ''


### PR DESCRIPTION
Only some dpdk runtime libraries are installed by default, but some
environments may need additional libraries installed. This adds an
option to allow the user to specify additional dpdk runtime libraries
via a config option `dpdk-runtime-libraries`.

Closes-Bug: #1936850