### PR TITLE
Add BaseWallabyOVNChassisCharm class

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -945,17 +945,7 @@ class BaseUssuriOVNChassisCharm(BaseOVNChassisCharm):
         'neutron-ovn-metadata-agent']
 
 
-class BaseWallabyOVNChassisCharm(BaseOVNChassisCharm):
+class BaseWallabyOVNChassisCharm(BaseUssuriOVNChassisCharm):
     """Wallaby incarnation of the OVN Chassis base charm class."""
     abstract_class = True
     openstack_packages = ['neutron-ovn-metadata-agent', 'openstack-release']
-    openstack_services = ['neutron-ovn-metadata-agent']
-    openstack_restart_map = {
-        '/etc/neutron/neutron_ovn_metadata_agent.ini': [
-            'neutron-ovn-metadata-agent']}
-    nrpe_check_base_services = [
-        'ovn-controller',
-        'ovs-vswitchd',
-        'ovsdb-server']
-    nrpe_check_openstack_services = [
-        'neutron-ovn-metadata-agent']

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -943,3 +943,19 @@ class BaseUssuriOVNChassisCharm(BaseOVNChassisCharm):
         'ovsdb-server']
     nrpe_check_openstack_services = [
         'neutron-ovn-metadata-agent']
+
+
+class BaseWallabyOVNChassisCharm(BaseOVNChassisCharm):
+    """Wallaby incarnation of the OVN Chassis base charm class."""
+    abstract_class = True
+    openstack_packages = ['neutron-ovn-metadata-agent', 'openstack-release']
+    openstack_services = ['neutron-ovn-metadata-agent']
+    openstack_restart_map = {
+        '/etc/neutron/neutron_ovn_metadata_agent.ini': [
+            'neutron-ovn-metadata-agent']}
+    nrpe_check_base_services = [
+        'ovn-controller',
+        'ovs-vswitchd',
+        'ovsdb-server']
+    nrpe_check_openstack_services = [
+        'neutron-ovn-metadata-agent']

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -337,6 +337,11 @@ class Helper(test_utils.PatchHelper):
             self.patch(
                 'charms.ovn_charm.BaseTrainOVNChassisCharm.enable_openstack',
                 new_callable=self.enable_openstack)
+        elif release and release == 'wallaby':
+            self.target = ovn_charm.BaseWallabyOVNChassisCharm()
+            self.patch(
+                'charms.ovn_charm.BaseWallabyOVNChassisCharm.enable_openstack',
+                new_callable=self.enable_openstack)
         else:
             self.target = ovn_charm.BaseUssuriOVNChassisCharm()
             self.patch(
@@ -399,6 +404,30 @@ class TestUssuriOVNChassisCharm(Helper):
     def test_optional_openstack_metadata_ussuri(self):
         self.assertEquals(self.target.packages, [
             'ovn-host', 'neutron-ovn-metadata-agent'
+        ])
+        self.assertEquals(self.target.services, [
+            'ovn-host', 'neutron-ovn-metadata-agent'])
+        self.assertDictEqual(self.target.restart_map, {
+            '/etc/default/openvswitch-switch': [],
+            '/etc/neutron/neutron_ovn_metadata_agent.ini': [
+                'neutron-ovn-metadata-agent'],
+            '/etc/openvswitch/system-id.conf': [],
+        })
+        self.assertEquals(self.target.nrpe_check_services, [
+            'ovn-controller', 'ovs-vswitchd', 'ovsdb-server',
+            'neutron-ovn-metadata-agent'])
+
+
+class TestWallabyOVNChassisCharm(Helper):
+
+    def setUp(self):
+        super().setUp(release='wallaby')
+        self.enable_openstack.return_value = True
+
+    def test_optional_openstack_metadata_wallaby(self):
+        self.assertEquals(self.target.packages, [
+            'ovn-host', 'neutron-ovn-metadata-agent',
+            'openstack-release',
         ])
         self.assertEquals(self.target.services, [
             'ovn-host', 'neutron-ovn-metadata-agent'])


### PR DESCRIPTION
The openstack-release package is added in the Wallaby class as this
package was introduced in the wallaby release to make determination
of the OpenStack release codename easier.

Closes-Bug: #1951462