### PR TITLE
Update certificates offered over ovsdb-subordinate relation.

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -593,6 +593,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                                 tls_object['cert'],
                                 tls_object['key'],
                                 cn='host')
+            reactive.set_flag('ovn.certs.changed')
             break
         else:
             ch_core.hookenv.log('No certificate with CN matching hostname '

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -133,7 +133,7 @@ def configure_nrpe():
 @reactive.when_none('charm.paused', 'is-update-status-hook')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                'ovsdb-subordinate.available',
-               'certificates.available')
+               'ovn.certs.changed')
 def provide_chassis_certificates_to_principal():
     ovsdb_subordinate = reactive.endpoint_from_flag(
         'ovsdb-subordinate.available')
@@ -156,4 +156,7 @@ def provide_chassis_certificates_to_principal():
                     ovn_key.read())
     except OSError as e:
         ch_core.hookenv.log('Unable to provide principal with '
-                            'chassis certificates: "{}"'.format(str(e)))
+                            'chassis certificates: "{}"'.format(str(e)),
+                            level=ch_core.hookenv.WARNING)
+
+    reactive.clear_flag('ovn.certs.changed')

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -63,7 +63,7 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                 'provide_chassis_certificates_to_principal': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
                     'ovsdb-subordinate.available',
-                    'certificates.available'),
+                    'ovn.certs.changed'),
             },
             'when_none': {
                 'amqp_connection': ('charm.paused', 'is-update-status-hook'),


### PR DESCRIPTION
When OVN is reconfigured with a new set of certificates, those need to
be updated over the ovsdb-subordinate relation "chassis-certificates"
key. This allows the principle charm (e.g. Octavia charm) to reconfigure
itself with the new certificates.

Closes-Bug: #1952279