### PR TITLE
Add a new option: card-serial-number

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -297,3 +297,14 @@ options:
       .
       Changing this config option will restart openvswitch-switch, resulting
       in an expected data plane outage while the service restarts.
+  card-serial-number:
+    type: string
+    default:
+    description: |
+      A card serial number of a networking controller present in its Vital
+      Product Data (VPD). This option can be used to enable SmartNIC DPU support.
+      .
+      Used to set up a mapping between a chassis hostname and a unique card serial
+      number of a NIC in the southbound database. This can then used by the CMS
+      to look up which chassis should service a port plugging request based on the
+      information provided from a hypervisor host.

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -940,12 +940,20 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         else:
             opvs.remove('.', 'external_ids', 'ovn-bridge-mappings')
 
-        if self.options.prefer_chassis_as_gw:
-            opvs.set(
-                '.', 'external_ids:ovn-cms-options', 'enable-chassis-as-gw')
+        cms_opts = self._format_ovn_cms_options()
+        if cms_opts:
+            opvs.set('.', 'external_ids:ovn-cms-options', ','.join(cms_opts))
         else:
-            opvs.remove(
-                '.', 'external_ids', 'ovn-cms-options=enable-chassis-as-gw')
+            opvs.remove('.', 'external_ids', 'ovn-cms-options')
+
+    def _format_ovn_cms_options(self):
+        cms_opts = []
+        if self.options.prefer_chassis_as_gw:
+            cms_opts.append('enable-chassis-as-gw')
+        if self.options.card_serial_number:
+            cms_opts.append(
+                f'card-serial-number={self.options.card_serial_number}')
+        return cms_opts
 
     def render_nrpe(self):
         """Configure Nagios NRPE checks."""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,6 @@ coverage>=3.6
 mock>=1.2
 pep8>=1.7.0
 flake8>=2.2.4
-os-testr>=0.4.1
+stestr>=1.0.0
 
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -325,6 +325,7 @@ class Helper(test_utils.PatchHelper):
                 'enable-dpdk': False,
                 'bridge-interface-mappings': 'br-ex:eth0',
                 'prefer-chassis-as-gw': False,
+                'card-serial-number': 'c4rd-53r14l',
             }
             if x:
                 return cfg.get(x)
@@ -406,6 +407,7 @@ class TestDPDKOVNChassisCharmExtraLibs(Helper):
                 'provider:br-ex other:br-data'),
             'prefer-chassis-as-gw': False,
             'dpdk-runtime-libraries': '',
+            'card-serial-number': '',
         }
         super().setUp(config=self.local_config)
 
@@ -588,6 +590,7 @@ class TestDPDKOVNChassisCharm(Helper):
                 'provider:br-ex other:br-data'),
             'prefer-chassis-as-gw': False,
             'dpdk-runtime-libraries': '',
+            'card-serial-number': '',
         })
 
     def test__init__(self):
@@ -714,7 +717,7 @@ class TestDPDKOVNChassisCharm(Helper):
             '.', 'external_ids:ovn-bridge-mappings',
             'other:br-data,provider:br-ex')
         ovsdb.open_vswitch.remove.assert_called_once_with(
-            '.', 'external_ids', 'ovn-cms-options=enable-chassis-as-gw')
+            '.', 'external_ids', 'ovn-cms-options')
 
 
 class TestOVNChassisCharm(Helper):
@@ -729,6 +732,7 @@ class TestOVNChassisCharm(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-provider other:br-other'),
             'prefer-chassis-as-gw': True,
+            'card-serial-number': 'c4rd-53r14l',
         })
 
     def test_optional_openstack_metadata(self):
@@ -1025,7 +1029,7 @@ class TestOVNChassisCharm(Helper):
             mock.call('.', 'external_ids:ovn-bridge-mappings',
                       'other:br-other,provider:br-provider'),
             mock.call('.', 'external_ids:ovn-cms-options',
-                      'enable-chassis-as-gw'),
+                      'enable-chassis-as-gw,card-serial-number=c4rd-53r14l'),
         ], any_order=True)
 
     def test_wrong_configure_bridges(self):


### PR DESCRIPTION
This option can be used to specify a card serial number of a networking
controller present in its Vital Product Data (VPD) to enable SmartNIC
DPU support.