### PR TITLE
Ensure that deferred events don't break install

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -133,12 +133,18 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
+
+        # Run configure_ovs if config.rendered is not set.
+        # This ensures that configure_ovs hook will run when installing a new
+        # unit even if enable-auto-restarts is set to False LP#1943970
+        config_rendered = reactive.flags.is_flag_set('config.rendered')
+
         changed = reactive.flags.is_flag_set(
             'config.changed.enable-auto-restarts')
         # Run method if enable-auto-restarts has changed, irrespective of what
         # it was changed to. This ensure that this method is not immediately
         # deferred when enable-auto-restarts is initially set to False.
-        if ((not check_deferred_events) or changed or
+        if ((not config_rendered) or (not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('configure_ovs')
             super().configure_ovs(sb_conn, mlockall_changed)
@@ -152,12 +158,17 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
+        # Run the install if config.rendered is not set.
+        # This ensures that install hook will run when installing a new
+        # unit even if enable-auto-restarts is set to False LP#1943970
+        config_rendered = reactive.flags.is_flag_set('config.rendered')
+
         changed = reactive.flags.is_flag_set(
             'config.changed.enable-auto-restarts')
         # Run method if enable-auto-restarts has changed, irrespective of what
         # it was changed to. This ensure that this method is not immediately
         # deferred when enable-auto-restarts is initially set to False.
-        if ((not check_deferred_events) or changed or
+        if ((not config_rendered) or (not check_deferred_events) or changed or
                 deferred_events.is_restart_permitted()):
             deferred_events.clear_deferred_hook('install')
             super().install()

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -36,6 +36,37 @@ _DEFERABLE_SVC_LIST = ['openvswitch-switch', 'ovn-controller', 'ovn-host',
                        'ovs-vswitchd', 'ovsdb-server', 'ovs-record-hostname']
 
 
+def is_deferred_event_permitted(config_rendered, enable_auto_restarts_changed,
+                                check_deferred_events, is_restart_permitted):
+    """Check whether a deferred event can run or not.
+
+    :param config_rendered: true if config.rendered flag is set. When this
+                            flag is not set, deferred events are permitted
+                            to allow completing first installation.
+    :type config_rendered: bool
+    :param enable_auto_restarts_changed: true if enable_auto_restarts
+                                         changed since last iteration.
+                                         If enable-auto-restarts has
+                                         changed, deferred events will be
+                                         permitted irrespective of what it
+                                         was changed to. This ensures that
+                                         this method is not immediately
+                                         deferred when enable-auto-restarts
+                                         is initially set to False.
+    :type enable_auto_restarts_changed: bool
+    :param check_deferred_events: Whether to check if restarts are
+                                  permitted before running hook.
+    :type check_deferred_events: bool
+    :param is_restart_permitted: if true deferred events can run.
+    :type is_restart_permitted: bool
+    """
+
+    if ((not config_rendered) or (not check_deferred_events) or
+            enable_auto_restarts_changed or is_restart_permitted):
+        return True
+    return False
+
+
 class DeferredEventMixin():
     """Mixin to add to charm class to add support for deferred events."""
 
@@ -133,19 +164,14 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
-
-        # Run configure_ovs if config.rendered is not set.
-        # This ensures that configure_ovs hook will run when installing a new
-        # unit even if enable-auto-restarts is set to False LP#1943970
         config_rendered = reactive.flags.is_flag_set('config.rendered')
-
         changed = reactive.flags.is_flag_set(
-            'config.changed.enable-auto-restarts')
-        # Run method if enable-auto-restarts has changed, irrespective of what
-        # it was changed to. This ensure that this method is not immediately
-        # deferred when enable-auto-restarts is initially set to False.
-        if ((not config_rendered) or (not check_deferred_events) or changed or
-                deferred_events.is_restart_permitted()):
+            'config.changed.enable-auto-restarts'
+        )
+        is_restart_permitted = deferred_events.is_restart_permitted()
+        if is_deferred_event_permitted(config_rendered, changed,
+                                       check_deferred_events,
+                                       is_restart_permitted):
             deferred_events.clear_deferred_hook('configure_ovs')
             super().configure_ovs(sb_conn, mlockall_changed)
         else:
@@ -158,18 +184,14 @@ class DeferredEventMixin():
                                       permitted before running hook.
         :type check_deferred_events: bool
         """
-        # Run the install if config.rendered is not set.
-        # This ensures that install hook will run when installing a new
-        # unit even if enable-auto-restarts is set to False LP#1943970
         config_rendered = reactive.flags.is_flag_set('config.rendered')
-
         changed = reactive.flags.is_flag_set(
-            'config.changed.enable-auto-restarts')
-        # Run method if enable-auto-restarts has changed, irrespective of what
-        # it was changed to. This ensure that this method is not immediately
-        # deferred when enable-auto-restarts is initially set to False.
-        if ((not config_rendered) or (not check_deferred_events) or changed or
-                deferred_events.is_restart_permitted()):
+            'config.changed.enable-auto-restarts'
+        )
+        is_restart_permitted = deferred_events.is_restart_permitted()
+        if is_deferred_event_permitted(config_rendered, changed,
+                                       check_deferred_events,
+                                       is_restart_permitted):
             deferred_events.clear_deferred_hook('install')
             super().install()
         else:

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -22,6 +22,7 @@ import charms_openstack.charm.core as chm_core
 import charms_openstack.test_utils as test_utils
 
 import charms.ovn_charm as ovn_charm
+from charms.ovn_charm import is_deferred_event_permitted
 
 
 class TestDeferredEventMixin(test_utils.PatchHelper):
@@ -143,116 +144,79 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
             (None, None))
 
     def test_configure_ovs(self):
-        self.patch_object(ovn_charm.deferred_events, 'is_restart_permitted')
+        self.patch_object(ovn_charm, 'is_deferred_event_permitted')
         self.patch_object(ovn_charm.deferred_events, 'clear_deferred_hook')
-        self.patch_object(ovn_charm.deferred_events, 'set_deferred_hook')
-        self.patch_object(ovn_charm.reactive.flags, 'is_flag_set')
 
-        # Tests with restarts permitted
+        # Test deferred events are permitted
+        self.is_deferred_event_permitted.return_value = True
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.is_restart_permitted.return_value = True
         self.charm_instance.configure_ovs(
             's_conn',
             'mlockall_changed',
             check_deferred_events=True)
         self.clear_deferred_hook.assert_called_once_with('configure_ovs')
 
+        # Test deferred events are not permitted
+        self.is_deferred_event_permitted.return_value = False
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.charm_instance.configure_ovs(
-            's_conn',
-            'mlockall_changed',
-            check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
-
-        # Tests with restarts not permitted
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.is_restart_permitted.return_value = False
         self.charm_instance.configure_ovs(
             's_conn',
             'mlockall_changed',
             check_deferred_events=True)
         self.assertFalse(self.clear_deferred_hook.called)
-
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.charm_instance.configure_ovs(
-            's_conn',
-            'mlockall_changed',
-            check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
-
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [False, True]
-        self.is_restart_permitted.return_value = False
-        self.charm_instance.configure_ovs(
-            's_conn',
-            'mlockall_changed',
-            check_deferred_events=True)
-        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
-
-        # Tests with restarts not permitted from this hooks onwards.
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, True]
-        self.is_restart_permitted.return_value = False
-        self.is_flag_set.return_value = True
-        self.charm_instance.configure_ovs(
-            's_conn',
-            'mlockall_changed',
-            check_deferred_events=True)
-        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
-
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.charm_instance.configure_ovs(
-            's_conn',
-            'mlockall_changed',
-            check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
 
     def test_install(self):
-        self.patch_object(ovn_charm.deferred_events, 'is_restart_permitted')
+        self.patch_object(ovn_charm, 'is_deferred_event_permitted')
         self.patch_object(ovn_charm.deferred_events, 'clear_deferred_hook')
-        self.patch_object(ovn_charm.deferred_events, 'set_deferred_hook')
-        self.patch_object(ovn_charm.reactive.flags, 'is_flag_set')
 
-        # Tests with restarts permitted
+        # Test deferred events are permitted
+        self.is_deferred_event_permitted.return_value = True
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.is_restart_permitted.return_value = True
         self.charm_instance.install(check_deferred_events=True)
         self.clear_deferred_hook.assert_called_once_with('install')
 
+        # Test deferred events are not permitted
+        self.is_deferred_event_permitted.return_value = False
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.charm_instance.install(check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('install')
-
-        # Tests with restarts not permitted
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.is_restart_permitted.return_value = False
         self.charm_instance.install(check_deferred_events=True)
         self.assertFalse(self.clear_deferred_hook.called)
 
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, False]
-        self.charm_instance.install(check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('install')
+    def test_deferred_event_is_not_permitted(self):
+        # Only case when deferred event is not permitted
+        config_rendered = True
+        enable_auto_restarts_changed = False
+        check_deferred_events = True
+        is_restart_permitted = False
 
-        # Tests with restarts not permitted from this hooks onwards.
-        self.clear_deferred_hook.reset_mock()
-        self.is_restart_permitted.return_value = False
-        self.is_flag_set.side_effect = [True, True]
-        self.charm_instance.install(check_deferred_events=True)
-        self.clear_deferred_hook.assert_called_once_with('install')
+        self.assertFalse(is_deferred_event_permitted(
+            config_rendered, enable_auto_restarts_changed,
+            check_deferred_events, is_restart_permitted))
 
-        self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.side_effect = [True, True]
-        self.charm_instance.install(check_deferred_events=False)
-        self.clear_deferred_hook.assert_called_once_with('install')
+    def test_deferred_event_is_permitted(self):
+        # All cases when deferred event is permitted
+        test_cases = [
+            [True, True, True, True],
+            [True, False, True, True],
+            [True, True, False, True],
+            [True, True, True, False],
+            [True, False, False, True],
+            [True, True, False, False],
+            [True, False, False, False],
+
+            [False, False, False, False],
+            [False, True, False, False],
+            [False, False, True, False],
+            [False, False, False, True],
+            [False, True, True, False],
+            [False, True, False, True],
+            [False, False, True, True],
+            [False, True, True, True],
+        ]
+
+        for test_case in test_cases:
+            self.assertTrue(is_deferred_event_permitted(
+                test_case[0], test_case[1], test_case[2], test_case[3]
+            ))
 
 
 class TestOVNConfigurationAdapter(test_utils.PatchHelper):

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -150,7 +150,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
 
         # Tests with restarts permitted
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.return_value = False
+        self.is_flag_set.side_effect = [True, False]
         self.is_restart_permitted.return_value = True
         self.charm_instance.configure_ovs(
             's_conn',
@@ -159,6 +159,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
         self.clear_deferred_hook.assert_called_once_with('configure_ovs')
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.charm_instance.configure_ovs(
             's_conn',
             'mlockall_changed',
@@ -167,6 +168,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
 
         # Tests with restarts not permitted
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.is_restart_permitted.return_value = False
         self.charm_instance.configure_ovs(
             's_conn',
@@ -175,14 +177,25 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
         self.assertFalse(self.clear_deferred_hook.called)
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.charm_instance.configure_ovs(
             's_conn',
             'mlockall_changed',
             check_deferred_events=False)
         self.clear_deferred_hook.assert_called_once_with('configure_ovs')
 
+        self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [False, True]
+        self.is_restart_permitted.return_value = False
+        self.charm_instance.configure_ovs(
+            's_conn',
+            'mlockall_changed',
+            check_deferred_events=True)
+        self.clear_deferred_hook.assert_called_once_with('configure_ovs')
+
         # Tests with restarts not permitted from this hooks onwards.
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, True]
         self.is_restart_permitted.return_value = False
         self.is_flag_set.return_value = True
         self.charm_instance.configure_ovs(
@@ -192,6 +205,7 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
         self.clear_deferred_hook.assert_called_once_with('configure_ovs')
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.charm_instance.configure_ovs(
             's_conn',
             'mlockall_changed',
@@ -206,33 +220,37 @@ class TestDeferredEventMixin(test_utils.PatchHelper):
 
         # Tests with restarts permitted
         self.clear_deferred_hook.reset_mock()
-        self.is_flag_set.return_value = False
+        self.is_flag_set.side_effect = [True, False]
         self.is_restart_permitted.return_value = True
         self.charm_instance.install(check_deferred_events=True)
         self.clear_deferred_hook.assert_called_once_with('install')
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.charm_instance.install(check_deferred_events=False)
         self.clear_deferred_hook.assert_called_once_with('install')
 
         # Tests with restarts not permitted
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.is_restart_permitted.return_value = False
         self.charm_instance.install(check_deferred_events=True)
         self.assertFalse(self.clear_deferred_hook.called)
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, False]
         self.charm_instance.install(check_deferred_events=False)
         self.clear_deferred_hook.assert_called_once_with('install')
 
         # Tests with restarts not permitted from this hooks onwards.
         self.clear_deferred_hook.reset_mock()
         self.is_restart_permitted.return_value = False
-        self.is_flag_set.return_value = True
+        self.is_flag_set.side_effect = [True, True]
         self.charm_instance.install(check_deferred_events=True)
         self.clear_deferred_hook.assert_called_once_with('install')
 
         self.clear_deferred_hook.reset_mock()
+        self.is_flag_set.side_effect = [True, True]
         self.charm_instance.install(check_deferred_events=False)
         self.clear_deferred_hook.assert_called_once_with('install')
 


### PR DESCRIPTION
If config.rendered is not set it means that configure_ovs hasn't run
yet for the first time. This change allows to run install and
configure_ovs method until the first installation is not completed.

Closes-Bug: 1943970