### PR TITLE
Pin jsonschema to < 4.6

### DIFF
--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -469,8 +469,8 @@ class Helper(test_utils.PatchHelper):
         # remove the 'is_flag_set' patch so the tests can use it
         self._patches['is_flag_set'].stop()
         setattr(self, 'is_flag_set', None)
-        del(self._patches['is_flag_set'])
-        del(self._patches_start['is_flag_set'])
+        del self._patches['is_flag_set']
+        del self._patches_start['is_flag_set']
 
         self.patch('charmhelpers.contrib.openstack.context.DPDKDeviceContext',
                    name='DPDKDeviceContext')

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,1 @@
-jsonschema
+jsonschema<4.6


### PR DESCRIPTION
Due to the linked bug below, jsonschema >=4.6 now requires
hatchling to build the jsonschema module. In reactive charms, this
happens at install time, but the charm build tool (using pip) doesn't
detect the build dependency for jsonschema.  Therefore, for the moment,
pin the dependency until a more strategic solution is found.

Closes LP Bug: #1987702