### PR TITLE
Add prometheus-ovs-exporter snap support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -331,4 +331,10 @@ options:
       should not normally happen with DPUs that only have one chip exposed.
       .
       Examples: [{"bus": "pci", "vendor_id": "15b3", "product_id": "a2d6" },
-
+  ovs-exporter-channel:
+    type: string
+    default: stable
+    description: >-
+      The snap channel to install the prometheus-ovs-exporter from. Setting
+      this option to an empty string will result in the snap not being
+      installed or removed if it has already been installed.

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,6 +3,7 @@ includes:
   - interface:ovsdb
   - interface:rabbitmq
   - interface:nrpe-external-master
+  - layer:snap
 exclude: 
   - .gitignore
   - .stestr.conf

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -378,6 +378,23 @@ class OVNConfigurationAdapter(
         self._validation_errors['pmd-cpu-mask'] = (
             'Fix overlap between dpdk-lcore-mask and pmd-cpu-mask.')
 
+    @property
+    def ovs_exporter_snap_channel(self):
+        """Validate a provided snap channel and return it
+
+        Any prefix is ignored ('0.10' in '0.10/stable' for example). If
+        a config value is empty it means that the snap does not need to
+        be installed.
+        """
+        channel = self.ovs_exporter_channel
+        if not channel:
+            return None
+
+        channel_suffix = channel.split('/')[-1]
+        if channel_suffix not in ('stable', 'candidate', 'beta', 'edge'):
+            return 'stable'
+        return channel_suffix
+
 
 class NeutronPluginRelationAdapter(
         charms_openstack.adapters.OpenStackRelationAdapter):

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -59,6 +59,11 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'ovsdb-subordinate.available',
                     'ovn.certs.changed'),
             },
+            'when_not': {
+                'snap_install': (
+                    'snap.installed.prometheus-ovs-exporter',
+                )
+            },
             'when_none': {
                 'amqp_connection': ('charm.paused', 'is-update-status-hook'),
                 'disable_openstack': (
@@ -85,6 +90,9 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'config.changed.nagios_servicegroups',
                     'endpoint.nrpe-external-master.changed',
                     'nrpe-external-master.available'),
+                'reassess_exporter': (
+                    'config.changed.ovs-exporter-channel',
+                    'snap.installed.prometheus-ovs-exporter'),
             },
         }
         # test that the hooks were registered via the


### PR DESCRIPTION
Both ovn-dedicated-chassis and ovn-chassis can utilize
the prometheus-ovs-exporter snap in order to provide metrics to
prometheus.

This change adds an option to specify a channel for the snap or lack
thereof (in which case it will not be installed or removed).

The snap is currently installed in devmode due to the lack of relevant
interfaces that the exporter needs.
