### PR TITLE
Fix a renamed method call

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -706,7 +706,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             ])
             return 'blocked', status_msg
 
-        if self.options.enable_dpdk and self.ovs_dpdk_cpu_overlap_check():
+        if self.options.enable_dpdk and self._ovs_dpdk_cpu_overlap_check():
             ch_core.hookenv.log('Overlap detected between dpdk-lcore-mask '
                                 'and pmd-cpu-mask.',
                                 level=ch_core.hookenv.WARNING)


### PR DESCRIPTION
0851229ef96216a97ee9d072cbb13afb38c63c0a renamed the method
ovs_dpdk_cpu_overlap_check to _ovs_dpdk_cpu_overlap_check while one of
the usages of it was not updated to match.