### PR TITLE
Add iptables NOTRACK rules for excluding GENEVE traffic from nf_conntrack

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1182,3 +1182,54 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         nrpe.add_init_service_checks(
             charm_nrpe, self.nrpe_check_services, current_unit)
         charm_nrpe.write()
+
+    def configure_iptables_rules(self):
+        """
+        Configure `iptables` NOTRACK rules for GENEVE traffic in nf_conntrack
+
+        The GENEVE/VXLAN traffic has randomized source ports[1], which
+        plays badly with nf_conntrack in a busy cloud environment. Having
+        randomized source ports change the five-tuple info, resulting to an
+        increase in unique connections that nf_conntrack tracks. That
+        inevitably leads to a full nf_conntrack table and connections to be
+        dropped.
+
+        NOTRACK rules allow nf_conntrack to ignore the said traffic. UDP
+        flows with destination port 6081 will not be tracked by nf_conntrack
+        while rules are in effect.
+
+        [1]:(https://datatracker.ietf.org/doc/html/rfc8926#section-3.3)
+        """
+        ch_core.hookenv.log("Configuring iptables rules",
+                            level=ch_core.hookenv.INFO)
+
+        def append_notrack_rule(chain_name):
+            """
+            Append a iptables NOTRACK rule to a chain in raw table.
+
+            :param str chain_name: Chain to append
+            """
+            args = ['iptables', '-t', 'raw', '-C', chain_name, '-p', 'udp',
+                    '--dport', '6081', '-j', 'NOTRACK']
+            try:
+                self.run(*args)
+                ch_core.hookenv.log(
+                    "Rule `{}` append to `{}` chain skipped (already exists)"
+                    .format(' '.join(args), chain_name),
+                    level=ch_core.hookenv.INFO)
+            except subprocess.CalledProcessError as cpe:
+                if cpe.returncode != 1:
+                    raise
+
+                # Append command is exactly the same with check
+                # except the check (-C) is replaced with append
+                # (-A)
+                args[3] = '-A'
+                self.run(*args)
+                ch_core.hookenv.log(
+                    "Rule `{}` appended to `{}` chain"
+                    .format(' '.join(args), chain_name),
+                    level=ch_core.hookenv.INFO)
+
+        append_notrack_rule('PREROUTING')
+        append_notrack_rule('OUTPUT')

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -93,6 +93,7 @@ def configure_ovs():
             reactive.is_flag_set('config.changed.disable-mlockall'))
         reactive.set_flag('config.rendered')
         charm_instance.configure_bridges()
+        charm_instance.configure_iptables_rules()
         charm_instance.assess_status()
 
 

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -152,6 +152,7 @@ class TestOvnHandlers(test_utils.PatchHelper):
                                      'amqp.connected'))
         self.set_flag.assert_called_once_with('config.rendered')
         self.charm.configure_bridges.assert_called_once_with()
+        self.charm.configure_iptables_rules.assert_called_once_with()
         self.charm.assess_status.assert_called_once_with()
 
     def test_configure_nrpe(self):


### PR DESCRIPTION
On some busy cloud deployments, it has been reported that the nodes
hosting the ovn-chassis are getting their nf-conntrack tables full
and starting to drop connections. The reason is that GENEVE uses
source port randomization, and the number of "unique" flows is high
from the nf-conntrack's perspective. This is no surprise since flows
are usually identified with their five-tuple (srcip/[srcport]/dstip/dstport/tproto)
by network elements, and GENEVE is leveraging this fact to have an
even distribution in load-balancing systems in between ([*]). The
randomization causes the nf_conntrack table to be flooded with many
GENEVE flows, eventually leading to connection drops in a busy
environment. As there is no particular reason and benefit to track
these flows at the moment, the solution is to exclude GENEVE traffic
from nf-conntrack tracking. This can be done by putting rules with
`-j NOTRACK` jump into relevant iptables chains, which many people
already use as a solution to this problem.

This change incorporates the relevant rules to the charm code, so the
rules become present by default.

Closes-bug: #1978806

[*]: https://datatracker.ietf.org/doc/html/rfc8926#section-3.3