### PR TITLE
Pin pyrsistent to 0.17.3

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,2 @@
 jsonschema<4.6
+pyrsistent<=0.17.3


### PR DESCRIPTION
pyrsistent >= 18.0.0 requires setuptools >= 42.0.0 which is currently
causes a problem during the install hook exeuction as we pin to a lower
version of setuptools.

As a temporary solution until (if) we transition to binary builds for
reactive charms, this change addresses that by using pinning.