### PR TITLE
Fix the overlap method invocation

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -706,7 +706,8 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             ])
             return 'blocked', status_msg
 
-        if self.options.enable_dpdk and self._ovs_dpdk_cpu_overlap_check():
+        if (self.options.enable_dpdk and
+                self.options._ovs_dpdk_cpu_overlap_check()):
             ch_core.hookenv.log('Overlap detected between dpdk-lcore-mask '
                                 'and pmd-cpu-mask.',
                                 level=ch_core.hookenv.WARNING)

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -885,6 +885,8 @@ class TestDPDKOVNChassisCharm(Helper):
         opvs = mock.MagicMock()
         self.SimpleOVSDB.return_value = opvs
 
+        self._ovs_dpdk_cpu_overlap_check.return_value = False
+
         # No existing config, confirm restart and values set as expected
         opvs.open_vswitch.__iter__.return_value = [
             {'other_config': {}}]
@@ -941,6 +943,9 @@ class TestDPDKOVNChassisCharm(Helper):
         self.assertTrue(self.target.configure_ovs_dpdk())
         opvs.open_vswitch.remove.assert_called_once_with(
             '.', 'other_config', 'pmd-cpu-mask')
+
+        self.assertEqual(self.target.custom_assess_status_last_check(),
+                         (None, None))
 
     def test_purge_packages(self):
         self.assertEquals(


### PR DESCRIPTION
2ef7f9ae209d5895bab6d142678e59c8300c8440 fixed the naming but the method
is on the config adapter not on the charm class. At the same time, the
this code path was not covered by unit tests which is why the issue was
not caught automatically.