### PR TITLE
Fix a regression introduced in 0851229e

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1102,8 +1102,12 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                                 'port interface configuration tasks.',
                                 level=ch_core.hookenv.INFO)
             return
+
         bim = self.options.bridge_interface_map
-        if not bim:
+        # A bridge interface mapping may be empty if an empty string is
+        # specified, however, this is different from an invalid mapping in
+        # which case the property returns None and we should not proceed.
+        if bim is None:
             return
 
         bond_config = os_context.BondConfig()

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -1336,6 +1336,23 @@ class TestOVNChassisCharm(Helper):
             self.target.custom_assess_status_last_check(),
             ('blocked', f'{self.target.bridges_key}: {expected_msg}'))
 
+    def test_empty_configure_bridges(self):
+        self.patch_object(ovn_charm.os_context, 'BridgePortInterfaceMap')
+        self.BridgePortInterfaceMap.return_value = {}
+
+        self.patch_target('check_if_paused')
+        self.check_if_paused.return_value = (None, None)
+        self.assertEqual(self.target.custom_assess_status_last_check(),
+                         (None, None))
+        self.target.configure_bridges()
+        self.BridgePortInterfaceMap.assert_called_once_with(
+            bridges_key='bridge-interface-mappings')
+
+        self.assertEqual(
+            self.target.custom_assess_status_last_check(),
+            (None, None)
+        )
+
     def test_wrong_vpd_spec(self):
         self.target.options.vpd_device_spec = '{'
         self.patch_target('check_if_paused')


### PR DESCRIPTION
A bridge interface mapping may be set to an empty string which was not
previously handled as invalid config - instead it resulted in an empty
BridgeInterfaceMap which was handled by configure_bridges accordingly
and ovn-cms-opts were set.

The regression made it such that ovn-cms-opts were not set in a case of
an empty BridgeInterfaceMap where as this should only happen when there
is an invalid config specified to the charm.

1) Test failure:
https://review.opendev.org/c/x/charm-ovn-dedicated-chassis/+/857878/2#message-37afbdf3f745d77719aa43afe5234aaa87d70468
2) Analysis:
https://review.opendev.org/c/x/charm-ovn-dedicated-chassis/+/857878/comments/ecde1283_4f1ba2c3
3) PDB output:
https://review.opendev.org/c/x/charm-ovn-dedicated-chassis/+/857878/comments/ecde1283_4f1ba2c3