### PR TITLE
Default to OVN 22.03 for fresh deployments on Focal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ options:
     default: distro
     type: string
     description: |
-      Repository from which to install OVS+OVN
+      Repository from which to install packages.
 
       May be one of the following:
 
@@ -19,7 +19,28 @@ options:
         cloud:bionic-rocky
 
       Note that updating this setting to a source that is known to
-      provide a later version of Ceph will trigger a software
+      provide a later version of OVN will trigger a software
+      upgrade.
+  ovn-source:
+    default: ''
+    type: string
+    description: |
+      Overlay repository from which to install OVS+OVN.
+
+      The default for this configuration option is determined at charm
+      runtime.
+
+      When charm is deployed into a fresh environment on Ubuntu
+      20.04 (Focal Fossa), the default will be 'focal-ovn-22.03'.
+
+      When charm is upgraded or deployed into a fresh environment
+      on a different series the default will be to not use the
+      overlay repository.
+
+      To disable the overlay repository, set this option to 'distro'.
+
+      Note that updating this setting to a source that is known to
+      provide a later version of OVN will trigger a software
       upgrade.
   bridge-interface-mappings:
     type: string

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,6 @@
 includes:
   - layer:openstack
+  - layer:leadership
   - interface:ovsdb
   - interface:rabbitmq
   - interface:nrpe-external-master


### PR DESCRIPTION
Add `ovn-source` configuration option which should be used in addition to the `source` configuration option.

The default of the `ovn-source` configuration option is determined at runtime based on whether the end user has provided config, whether its a fresh or upgraded charm deployment and which series it is deployed on.