### PR TITLE
Add prometheus-scrape interface

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -352,4 +352,10 @@ options:
       should not normally happen with DPUs that only have one chip exposed.
       .
       Examples: [{"bus": "pci", "vendor_id": "15b3", "product_id": "a2d6" },
-
+  ovs-exporter-channel:
+    type: string
+    default: stable
+    description: >-
+      The snap channel to install the prometheus-ovs-exporter from. Setting
+      this option to an empty string will result in the snap not being
+      installed or removed if it has already been installed.

--- a/layer.yaml
+++ b/layer.yaml
@@ -4,6 +4,7 @@ includes:
   - interface:ovsdb
   - interface:rabbitmq
   - interface:nrpe-external-master
+  - interface:prometheus-scrape
 exclude: 
   - .gitignore
   - .stestr.conf

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,4 +15,5 @@ provides:
   nrpe-external-master:
     interface: nrpe-external-master
     scope: container
-
+  metrics-endpoint:
+    interface: prometheus_scrape

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -182,14 +182,15 @@ def provide_chassis_certificates_to_principal():
     reactive.clear_flag('ovn.certs.changed')
 
 
+@reactive.when_none('is-update-status-hook')
 @reactive.when_any('config.changed.ovs-exporter-channel',
                    'snap.installed.prometheus-ovs-exporter')
 def reassess_exporter():
     with charm.provide_charm_instance() as instance:
-        channel = instance.options.ovs_exporter_snap_channel
-        charm.assess_exporter()
+        instance.assess_exporter()
 
 
+@reactive.when_none('is-update-status-hook')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'charm.installed',
                'metrics-endpoint.available',
                'snap.installed.prometheus-ovs-exporter')
@@ -202,6 +203,7 @@ def handle_metrics_endpoint():
         static_configs=[{"targets": ["*:9475"]}])
 
 
+@reactive.when_none('is-update-status-hook')
 @reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'charm.installed',
                'metrics-endpoint.available')
 @reactive.when_not('snap.installed.prometheus-ovs-exporter')

--- a/reactive/ovn_chassis_charm_handlers.py
+++ b/reactive/ovn_chassis_charm_handlers.py
@@ -21,7 +21,6 @@ import charms.reactive as reactive
 import charms_openstack.bus
 import charms_openstack.charm as charm
 
-from charms.layer import snap
 
 charms_openstack.bus.discover()
 OVN_CHASSIS_ENABLE_HANDLERS_FLAG = 'charm.ovn.chassis.enable-handlers'
@@ -186,26 +185,13 @@ def provide_chassis_certificates_to_principal():
 @reactive.when_any('config.changed.ovs-exporter-channel',
                    'snap.installed.prometheus-ovs-exporter')
 def reassess_exporter():
-    is_installed = snap.is_installed('prometheus-ovs-exporter')
-    channel = None
     with charm.provide_charm_instance() as instance:
         channel = instance.options.ovs_exporter_snap_channel
-
-    if channel is None:
-        # Attempt to remove the snap if it is present, the snap command
-        # returns 0 if the snap is not installed.
-        snap.remove('prometheus-ovs-exporter')
-        return
-
-    if is_installed:
-        snap.refresh('prometheus-ovs-exporter', channel=channel,
-                     devmode=True)
-    else:
-        snap.install('prometheus-ovs-exporter', channel=channel,
-                     devmode=True)
+        charm.assess_exporter()
 
 
-@reactive.when('metrics-endpoint.available',
+@reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'charm.installed',
+               'metrics-endpoint.available',
                'snap.installed.prometheus-ovs-exporter')
 def handle_metrics_endpoint():
     metrics_endpoint = reactive.endpoint_from_flag(
@@ -216,7 +202,8 @@ def handle_metrics_endpoint():
         static_configs=[{"targets": ["*:9475"]}])
 
 
-@reactive.when('metrics-endpoint.available')
+@reactive.when(OVN_CHASSIS_ENABLE_HANDLERS_FLAG, 'charm.installed',
+               'metrics-endpoint.available')
 @reactive.when_not('snap.installed.prometheus-ovs-exporter')
 def maybe_clear_metrics_endpoint():
     """Clear the metrics endpoint state if the exporter isn't installed.

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -68,10 +68,18 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                 'enable_install': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,),
                 'handle_metrics_endpoint': (
+                    handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
+                    'charm.installed',
                     'metrics-endpoint.available',
                     'snap.installed.prometheus-ovs-exporter',
                 ),
+                'reassess_exporter': (
+                    handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
+                    'charm.installed',
+                ),
                 'maybe_clear_metrics_endpoint': (
+                    handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,
+                    'charm.installed',
                     'metrics-endpoint.available',
                 ),
             },

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -114,6 +114,12 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'leadership.set.upgrade_stamp'),
                 'enable_install': (
                     'charm.installed', 'is-update-status-hook'),
+                'reassess_exporter': (
+                    'is-update-status-hook',),
+                'maybe_clear_metrics_endpoint': (
+                    'is-update-status-hook',),
+                'handle_metrics_endpoint': (
+                    'is-update-status-hook',),
             },
             'when_any': {
                 'configure_bridges': (

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -67,6 +67,21 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                     'leadership.is_leader'),
                 'enable_install': (
                     handlers.OVN_CHASSIS_ENABLE_HANDLERS_FLAG,),
+                'handle_metrics_endpoint': (
+                    'metrics-endpoint.available',
+                    'snap.installed.prometheus-ovs-exporter',
+                ),
+                'maybe_clear_metrics_endpoint': (
+                    'metrics-endpoint.available',
+                ),
+            },
+            'when_not': {
+                'snap_install': (
+                    'snap.installed.prometheus-ovs-exporter',
+                ),
+                'maybe_clear_metrics_endpoint': (
+                    'snap.installed.prometheus-ovs-exporter',
+                ),
             },
             'when_none': {
                 'amqp_connection': ('charm.paused', 'is-update-status-hook'),
@@ -105,6 +120,9 @@ class TestRegisteredHooks(test_utils.TestRegisteredHooks):
                 'enable_install': (
                     'leadership.set.install_stamp',
                     'leadership.set.upgrade_stamp'),
+                'reassess_exporter': (
+                    'config.changed.ovs-exporter-channel',
+                    'snap.installed.prometheus-ovs-exporter'),
             },
         }
         # test that the hooks were registered via the


### PR DESCRIPTION
## Add prometheus-scrape interface

* Install the prometheus-ovs-exporter snap if the relevant option is
  set appropriately (to a valid channel rather than an empty string);
* Provide the endpoint details to the prometheus-k8s-operator
  scrape_interface compatible relation (app and unit data);
* Remove the snap or ignore steps to install it if the option is set to
  an empty string;
* Clear the relation data for individual jobs if the snap is removed.

## Add unit tests & missing property

* the missing property on the adapter was added (it was exercised in
  manual functional testing but not added to the final commit by
  mistake);
* moved the logic for snap installation into the charm class;
* added unit tests for various snap install/remove/refresh scenarios.

## Avoid doing work during update-status hooks

Additionally, remove the unused variable in one of the handlers and use
an instance of the class.
