### PR TITLE
Add the missing snap layer

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,7 @@
 includes:
   - layer:openstack
   - layer:leadership
+  - layer:snap
   - interface:ovsdb
   - interface:rabbitmq
   - interface:nrpe-external-master


### PR DESCRIPTION
1ddb668997b4839208b72c1c13db1036f2ec1917 introduced the usage of the
snap layer for the ovs-exporter installation but missed adding the snap
layer to layer.yaml which was present in the manual functional testing.