### PR TITLE
Fix description of ovn-source configuration option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ options:
       runtime.
 
       When charm is deployed into a fresh environment on Ubuntu
-      20.04 (Focal Fossa), the default will be 'focal-ovn-22.03'.
+      20.04 (Focal Fossa), the default will be 'cloud:focal-ovn-22.03'.
 
       When charm is upgraded or deployed into a fresh environment
       on a different series the default will be to not use the


### PR DESCRIPTION
The current description erronously refers to 'focal-ovn-22.03' as a valid value, while the correct value is 'cloud:focal-ovn-22.03'.

Closes-Bug: #1992592