### PR TITLE
Connect ovs-exporter snap interfaces

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -20,6 +20,17 @@ options:
   basic:
     use_venv: true
     include_system_packages: false
+  snap:
+    prometheus-ovs-exporter:
+      connect:
+        - ['prometheus-ovs-exporter:kernel-module-observe', ':kernel-module-observe']
+        - ['prometheus-ovs-exporter:netlink-audit', ':netlink-audit']
+        - ['prometheus-ovs-exporter:log-observe', ':log-observe']
+        - ['prometheus-ovs-exporter:network-observe', ':network-observe']
+        - ['prometheus-ovs-exporter:openvswitch', ':openvswitch']
+        - ['prometheus-ovs-exporter:system-observe', ':system-observe']
+        # - ['prometheus-ovs-exporter:etc-openvswitch', ':system-files']
+        # - ['prometheus-ovs-exporter:run-openvswitch', ':system-files']
 repo: https://github.com/openstack-charmers/charm-layer-ovn
 config:
   deletes:

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1425,3 +1425,4 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         else:
             snap.install('prometheus-ovs-exporter', channel=channel,
                          devmode=True)
+        snap.connect_all()


### PR DESCRIPTION
Some plugs will not be auto-connected due to a policy decision.

https://forum.snapcraft.io/t/allow-use-of-system-files-interface-and-auto-connection-for-prometheus-ovs-exporter-and-prometheus-ovn-exporter/32179

Therefore, we do it in the charm using the infrastructure present in the
snap layer.

The system-files entries in layer-yaml are commented out pending a
review by policy-reviewers at forum.snapcraft.io.

Signed-off-by: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>