### PR TITLE
Enable strict confinement for the ovs exporter

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -29,8 +29,8 @@ options:
         - ['prometheus-ovs-exporter:network-observe', ':network-observe']
         - ['prometheus-ovs-exporter:openvswitch', ':openvswitch']
         - ['prometheus-ovs-exporter:system-observe', ':system-observe']
-        # - ['prometheus-ovs-exporter:etc-openvswitch', ':system-files']
-        # - ['prometheus-ovs-exporter:run-openvswitch', ':system-files']
+        - ['prometheus-ovs-exporter:etc-openvswitch', ':system-files']
+        - ['prometheus-ovs-exporter:run-openvswitch', ':system-files']
 repo: https://github.com/openstack-charmers/charm-layer-ovn
 config:
   deletes:

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1420,9 +1420,7 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
             return
 
         if is_installed:
-            snap.refresh('prometheus-ovs-exporter', channel=channel,
-                         devmode=True)
+            snap.refresh('prometheus-ovs-exporter', channel=channel)
         else:
-            snap.install('prometheus-ovs-exporter', channel=channel,
-                         devmode=True)
+            snap.install('prometheus-ovs-exporter', channel=channel)
         snap.connect_all()

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -1754,8 +1754,7 @@ class TestOVNChassisCharmOvsExporter(Helper):
 
         self.install.assert_called_once_with(
             'prometheus-ovs-exporter',
-            channel='stable',
-            devmode=True)
+            channel='stable')
         self.remove.assert_not_called()
         self.refresh.assert_not_called()
 
@@ -1771,8 +1770,7 @@ class TestOVNChassisCharmOvsExporter(Helper):
 
         self.refresh.assert_called_once_with(
             'prometheus-ovs-exporter',
-            channel='stable',
-            devmode=True)
+            channel='stable')
         self.install.assert_not_called()
         self.remove.assert_not_called()
 


### PR DESCRIPTION
Now that the use of system-files interface has been approved and the
prometheus-ovs-exporter snap with the relevant plugs has been released
to the store, devmode usage can be disabled and additional connections
can be made.

Signed-off-by: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>