### PR TITLE
Add support for OVN Router AZs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -355,3 +355,13 @@ options:
       The snap channel to install the prometheus-ovs-exporter from. Setting
       this option to an empty string will result in the snap not being
       installed or removed if it has already been installed.
+  availability-zone-mapping:
+    type: string
+    default:
+    description: |
+      A JSON string consisting of key-value mapping of chassis units as keys
+      and their availability-zone config as value. The value will be applied
+      to the 'external-ids:ovn-cms-options="availability-zones=<value>"' OVS
+      config of each chassis unit mapped to.
+      .
+      Examples: {"ovn-chassis/0": "az-0:az-1:az-2", "ovn-chassis/1": "az-1:az-3" }

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1341,6 +1341,15 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
         if self.options.card_serial_number:
             cms_opts.append(
                 f'card-serial-number={self.options.card_serial_number}')
+        if self.options.availability_zone_mapping:
+            try:
+                mapping = json.loads(self.options.availability_zone_mapping)
+                value = mapping.get(ch_core.hookenv.local_unit())
+                if value:
+                    cms_opts.append('availability-zones={}'.format(value))
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    'Failed to decode availability-zone-mapping: {}'.format(e))
         return cms_opts
 
     def render_nrpe(self):


### PR DESCRIPTION
OVN Router AZs can be configured through the
use of the
'external-ids:ovn-cms-options="availability-zones=<value>"' OVS config. This change adds a new config option to allow the value to be configured per chassis unit according to a JSON AZ mapping.