### PR TITLE
fix for new Github Actions 22.04 image

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v1

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
          CHARM_LAYERS_DIR={toxinidir}/layers
          CHARM_INTERFACES_DIR={toxinidir}/interfaces
          JUJU_REPOSITORY={toxinidir}/build
-passenv = http_proxy https_proxy INTERFACE_PATH
+passenv = http_proxy,https_proxy,INTERFACE_PATH
 install_command =
   pip install {opts} {packages}
 deps =


### PR DESCRIPTION
One may see the following error:
pep8: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'http_proxy https_proxy INTERFACE_PATH'