### PR TITLE
[stable/22.03] config/description: Drop experimental status for hardware offload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v1

--- a/config.yaml
+++ b/config.yaml
@@ -165,12 +165,8 @@ options:
     type: boolean
     default: false
     description: |
-      NOTE: Support for hardware offload in conjunction with OVN is an
-      experimental feature.
-      .
       Enable support for hardware offload of flows from Open vSwitch to
-      supported network adapters.  This feature has only been tested on
-      Mellanox ConnectX 5 adapters.
+      supported network adapters.
       .
       Enabling this option will make use of the sriov-numvfs option to
       configure the VF functions of the physical network adapters detected in
@@ -178,9 +174,9 @@ options:
       .
       This option must not be enabled with either enable-sriov or enable-dpdk.
       .
-      NOTE: Changing this value will not perform hardware specific adaption. A
-      manual restart of the hardware specific adaption service or reboot of the
-      system is required to apply configuration.
+      NOTE: Changing this value will not perform runtime changes to hardware
+      specific adaption. A reboot of the system is required to apply
+      configuration.
   enable-sriov:
     type: boolean
     default: false
@@ -259,8 +255,8 @@ options:
       spaces.
       .
       NOTE: Changing this value will have no effect on runtime configuration. A
-      manual restart of the `sriov-netplan-shim` service or reboot of the
-      system is required to apply configuration.
+      manual issue of the `netplan apply` command or reboot of the system is
+      required to apply configuration.
   new-units-paused:
     type: boolean
     default: false

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -427,7 +427,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     configuration_class = OVNConfigurationAdapter
     required_relations = [CERT_RELATION, 'ovsdb']
     python_version = 3
-    enable_openstack = False
     bridges_key = 'bridge-interface-mappings'
     # Extra packages and services to be installed, managed and monitored if
     # charm forms part of an Openstack Deployment

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
          CHARM_LAYERS_DIR={toxinidir}/layers
          CHARM_INTERFACES_DIR={toxinidir}/interfaces
          JUJU_REPOSITORY={toxinidir}/build
-passenv = http_proxy https_proxy INTERFACE_PATH
+passenv = http_proxy,https_proxy,INTERFACE_PATH
 install_command =
   pip install {opts} {packages}
 deps =


### PR DESCRIPTION
With the components listed in the charm-guide networking /ovn / hwol page [0], this feature is no longer considered to be experimental.

Fix up the wording around requirement for reboot to apply configuration.

Remove mention of the now deprecated `sriov-netplan-shim` service.

0: https://docs.openstack.org/charm-guide/latest/admin/networking/ovn/hardware-offload.html (cherry picked from commit 0597e4effacb7e419b5f36f055f5d9bf1f3452d6)