### PR TITLE
[stable] Make version pinning optional

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -305,3 +305,19 @@ options:
       .
       Changing this config option will restart openvswitch-switch, resulting
       in an expected data plane outage while the service restarts.
+  enable-version-pinning:
+    type: boolean
+    default: true
+    description: |
+      OVN is a distributed system, and special consideration must be given to
+      the process used to upgrade OVN.
+
+      In order to successfully perform a rolling upgrade, the ovn-controller
+      process needs to understand the structure of the database for the version
+      you are upgrading from and to simultaneously.
+
+      Rolling upgrades are supported as long as the span of versions used in
+      the system is within the previous and the next upstream OVN LTS version.
+
+      If you are upgrading across LTS boundaries you may need to use version
+      pinning to avoid data plane outage during the upgrade.

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -792,7 +792,8 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                            'external-ids:system-id={}'
                            .format(self.get_ovs_hostname()),
                            'external-ids:ovn-remote={}'.format(sb_conn),
-                           'external_ids:ovn-match-northd-version=true',
+                           'external_ids:ovn-match-northd-version={}'
+                           .format(self.options.enable_version_pinning),
                            ):
             cmd = cmd + ('--', 'set', 'open-vswitch', '.', ovs_ext_id)
         self.run(*cmd)

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -770,7 +770,7 @@ class TestDPDKOVNChassisCharm(Helper):
 class TestOVNChassisCharm(Helper):
 
     def setUp(self):
-        super().setUp(config={
+        self.local_config = {
             'enable-hardware-offload': False,
             'enable-sriov': False,
             'enable-dpdk': False,
@@ -779,7 +779,8 @@ class TestOVNChassisCharm(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-provider other:br-other'),
             'prefer-chassis-as-gw': True,
-        })
+            'enable-version-pinning': False}
+        super().setUp(config=self.local_config)
 
     def test_optional_openstack_metadata(self):
         self.assertEquals(self.target.packages, ['ovn-host'])
@@ -915,7 +916,7 @@ class TestOVNChassisCharm(Helper):
                 '--', 'set', 'open-vswitch', '.',
                 'external-ids:ovn-remote=fake-sb-conn-str',
                 '--', 'set', 'open-vswitch', '.',
-                'external_ids:ovn-match-northd-version=true',
+                'external_ids:ovn-match-northd-version=False',
             ),
         ])
         self.service_restart.assert_not_called()
@@ -941,7 +942,7 @@ class TestOVNChassisCharm(Helper):
                 '--', 'set', 'open-vswitch', '.',
                 'external-ids:ovn-remote=fake-sb-conn-str',
                 '--', 'set', 'open-vswitch', '.',
-                'external_ids:ovn-match-northd-version=true',
+                'external_ids:ovn-match-northd-version=False',
             ),
             mock.call('ovs-vsctl', '--id', '@manager',
                       'create', 'Manager', 'target="ptcp:6640:127.0.0.1"',
@@ -949,6 +950,39 @@ class TestOVNChassisCharm(Helper):
                       '@manager'),
         ])
         assert self.service_restart.called
+
+    def test_configure_ovs_version_pinning(self):
+        self.local_config.update({'enable-version-pinning': True})
+        self.target = ovn_charm.BaseOVNChassisCharm()
+        self.patch_target('run')
+        self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_key')
+        self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_cert')
+        self.patch_object(ovn_charm.OVNConfigurationAdapter, 'ovn_ca_cert')
+        self.patch_object(ovn_charm.ch_core.host, 'service_restart')
+        self.patch_target('get_data_ip')
+        self.get_data_ip.return_value = 'fake-data-ip'
+        self.patch_target('get_ovs_hostname')
+        self.get_ovs_hostname.return_value = 'fake-ovs-hostname'
+        self.patch_target('check_if_paused')
+        self.check_if_paused.return_value = (None, None)
+        self.target.configure_ovs('fake-sb-conn-str', False)
+        self.run.assert_has_calls([
+            mock.call('ovs-vsctl', '--no-wait', 'set-ssl',
+                      mock.ANY, mock.ANY, mock.ANY),
+            mock.call(
+                'ovs-vsctl',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-encap-type=geneve',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-encap-ip=fake-data-ip',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:system-id=fake-ovs-hostname',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-remote=fake-sb-conn-str',
+                '--', 'set', 'open-vswitch', '.',
+                'external_ids:ovn-match-northd-version=True',
+            ),
+        ])
 
     def test_render_nrpe(self):
         self.patch_object(ovn_charm.nrpe, 'NRPE')


### PR DESCRIPTION
The OVN charms prepared for the upgrade from OVN 20.03 to newer versions by unconditionally enabling version pinning.

Since then we have reached agreement with upstream that rolling upgrades should work when upgrading within the previous upstream LTS version and the next.

Having the pinning enabled may cause unnecessary grief for anyone already upgraded to OVN 22.03.

Add a charm configuration option to allow controlling the version pinning.

Closes-Bug: #2030944
Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>
(cherry picked from commit f68ecbd10d2109014c67100ec7e7fe8e1823a7ec) (cherry picked from commit 2a61104364a5e0c5b241a514f65b2323475ed96e) (cherry picked from commit bde8c8c7682872c56aa6f2e2693c95ca262b5431)