### PR TITLE
[stable/20.03] Fix ci errors

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -268,7 +268,6 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
     configuration_class = OVNConfigurationAdapter
     required_relations = [CERT_RELATION, 'ovsdb']
     python_version = 3
-    enable_openstack = False
     bridges_key = 'bridge-interface-mappings'
     valid_config = True
     # Services to be monitored by nrpe

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
          CHARM_LAYERS_DIR={toxinidir}/layers
          CHARM_INTERFACES_DIR={toxinidir}/interfaces
          JUJU_REPOSITORY={toxinidir}/build
-passenv = http_proxy https_proxy INTERFACE_PATH
+passenv = http_proxy,https_proxy,INTERFACE_PATH
 install_command =
   pip install {opts} {packages}
 deps =

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -351,8 +351,8 @@ class Helper(test_utils.PatchHelper):
         # remove the 'is_flag_set' patch so the tests can use it
         self._patches['is_flag_set'].stop()
         setattr(self, 'is_flag_set', None)
-        del(self._patches['is_flag_set'])
-        del(self._patches_start['is_flag_set'])
+        del self._patches['is_flag_set']
+        del self._patches_start['is_flag_set']
 
         self.patch('charmhelpers.contrib.openstack.context.DPDKDeviceContext',
                    name='DPDKDeviceContext')


### PR DESCRIPTION
Backports patches from stable/22.03 required to fix tox and pep8 errors