### PR TITLE
Bail out configuring ovs if no OVNSDB available

### DIFF
--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1118,20 +1118,28 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                  self.options.ovn_cert,
                  self.options.ovn_ca_cert)
 
-        # The local ``ovn-controller`` process will retrieve information about
-        # how to connect to OVN from the local Open vSwitch database.
-        cmd = ('ovs-vsctl',)
-        for ovs_ext_id in ('external-ids:ovn-encap-type=geneve',
-                           'external-ids:ovn-encap-ip={}'
-                           .format(self.get_data_ip()),
-                           'external-ids:system-id={}'
-                           .format(self.get_ovs_hostname()),
-                           'external-ids:ovn-remote={}'.format(sb_conn),
-                           'external_ids:ovn-match-northd-version={}'
-                           .format(self.options.enable_version_pinning),
-                           ):
-            cmd = cmd + ('--', 'set', 'open-vswitch', '.', ovs_ext_id)
-        self.run(*cmd)
+        if sb_conn:
+            # The local ``ovn-controller`` process will retrieve information
+            # about how to connect to OVN from the local Open vSwitch
+            # database.
+            cmd = ('ovs-vsctl',)
+            for ovs_ext_id in ('external-ids:ovn-encap-type=geneve',
+                               'external-ids:ovn-encap-ip={}'
+                               .format(self.get_data_ip()),
+                               'external-ids:system-id={}'
+                               .format(self.get_ovs_hostname()),
+                               'external-ids:ovn-remote={}'.format(sb_conn),
+                               'external_ids:ovn-match-northd-version={}'
+                               .format(self.options.enable_version_pinning),
+                               ):
+                cmd = cmd + ('--', 'set', 'open-vswitch', '.', ovs_ext_id)
+            self.run(*cmd)
+        else:
+            ch_core.hookenv.log('could not configure ovs due to unavailable '
+                                'sbdb connection info - ovn-central relation '
+                                'no longer available?',
+                                level=ch_core.hookenv.WARNING)
+
         if self.enable_openstack:
             # OpenStack Nova expects the local OVSDB server to listen to
             # TCP port 6640 on localhost.  We use this for the OVN metadata

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -14,13 +14,21 @@
 
 import sys
 
+import mock
+
 sys.path.append('lib')
 
 # Mock out charmhelpers so that we can test without it.
 import charms_openstack.test_mocks  # noqa
+
+# charms.openstack (commit b90327) re-introduced a dependency on charmhelpers
+# so we need to mock that out explicitly here since we do not install
+# charmhelpers as a test dependency.
+sys.modules['charmhelpers.contrib.openstack.utils'] = mock.MagicMock()
+sys.modules['charmhelpers.contrib.openstack.utils'].\
+    CompareOpenStackReleases = mock.MagicMock()
 charms_openstack.test_mocks.mock_charmhelpers()
 
-import mock
 import charms
 
 


### PR DESCRIPTION
When the ovsdb relation is departing the hook will fail since it will try to configure ovs while only partial information is available.

Closes-Bug: #1944983