### PR TITLE
[stable/22.03] Bail out configuring ovs if no OVNSDB available

### DIFF
--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -14,13 +14,21 @@
 
 import sys
 
+import mock
+
 sys.path.append('lib')
 
 # Mock out charmhelpers so that we can test without it.
 import charms_openstack.test_mocks  # noqa
+
+# charms.openstack (commit b90327) re-introduced a dependency on charmhelpers
+# so we need to mock that out explicitly here since we do not install
+# charmhelpers as a test dependency.
+sys.modules['charmhelpers.contrib.openstack.utils'] = mock.MagicMock()
+sys.modules['charmhelpers.contrib.openstack.utils'].\
+    CompareOpenStackReleases = mock.MagicMock()
 charms_openstack.test_mocks.mock_charmhelpers()
 
-import mock
 import charms
 
 

--- a/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
+++ b/unit_tests/test_reactive_ovn_chassis_charm_handlers.py
@@ -175,6 +175,26 @@ class TestOvnHandlers(test_utils.PatchHelper):
         self.charm.configure_iptables_rules.assert_called_once_with()
         self.charm.assess_status.assert_called_once_with()
 
+    def test_configure_ovs_no_sb_conn(self):
+        self.patch_object(handlers.reactive, 'endpoint_from_flag')
+        self.patch_object(handlers.charm, 'optional_interfaces')
+        self.patch_object(handlers.reactive, 'set_flag')
+        self.patch_object(handlers.reactive, 'is_flag_set', return_value=True)
+        ovsdb = mock.MagicMock()
+        ovsdb.db_sb_connection_strs = []
+        self.endpoint_from_flag.return_value = ovsdb
+        handlers.configure_ovs()
+        self.charm.configure_ovs.assert_called_once_with(
+            ','.join(ovsdb.db_sb_connection_strs), True)
+        self.charm.render_with_interfaces.assert_called_once_with(
+            self.optional_interfaces((ovsdb,),
+                                     'nova-compute.connected',
+                                     'amqp.connected'))
+        self.set_flag.assert_called_once_with('config.rendered')
+        self.charm.configure_bridges.assert_called_once_with()
+        self.charm.configure_iptables_rules.assert_called_once_with()
+        self.charm.assess_status.assert_called_once_with()
+
     def test_configure_nrpe(self):
         self.patch_object(handlers.reactive, 'endpoint_from_flag')
         self.endpoint_from_flag.return_value = 'nrpe-external-master'


### PR DESCRIPTION
When the ovsdb relation is departing the hook will fail since it will try to configure ovs while only partial information is available.

Closes-Bug: #1944983