### PR TITLE
dashboard: Typo in the title

### DIFF
--- a/files/dashboards/ovs-exporter-grafana.json
+++ b/files/dashboards/ovs-exporter-grafana.json
@@ -2084,7 +2084,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Juju: OVN Chassis - 2",
+  "title": "Juju: OVN Chassis",
   "uid": "8e37e6a37d6f74051089a4a867c6216bcd9d6c93",
   "version": 14,
   "weekStart": ""


### PR DESCRIPTION
Grafana dahsboard has an unnecessary "version" in the title which was left over from testing.