### PR TITLE
wheelhouse: Restrict rpds_py<0.25

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,11 @@
 jsonschema
+# rpds_py is a dependency of jsonschema.
+# Since version 0.25 it depends on rust edition 2024 which
+# became stable in rust 1.85.0[0]. This version of rust toolchain
+# is not available in the noble.
+#
+# [0] https://doc.rust-lang.org/beta/releases.html#version-1851-2025-03-18
+rpds_py<0.25
 
 # https://github.com/pallets/jinja/issues/1496
 # https://github.com/juju/charm-tools/issues/646


### PR DESCRIPTION
Newer versions of rpds_py require rust toolchain
that is not available in Ubuntu Noble.