### PR TITLE
23.03 backport: Add ovn-monitor-all configuration option to ovn-controller

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -371,3 +371,11 @@ options:
 
       If you are upgrading across LTS boundaries you may need to use version
       pinning to avoid data plane outage during the upgrade.
+  ovn-monitor-all:
+    type: boolean
+    default: false
+    description: |
+      A boolean value that tells if ovn-controller should monitor all records 
+      of tables in the OVN_Southbound database. If this option is set to false, 
+      ovn-controller will conditionally monitor only the records that are 
+      needed for the local chassis.

--- a/lib/charms/ovn_charm.py
+++ b/lib/charms/ovn_charm.py
@@ -1131,6 +1131,8 @@ class BaseOVNChassisCharm(charms_openstack.charm.OpenStackCharm):
                                'external-ids:ovn-remote={}'.format(sb_conn),
                                'external_ids:ovn-match-northd-version={}'
                                .format(self.options.enable_version_pinning),
+                               'external-ids:ovn-monitor-all={}'
+                               .format(self.options.ovn_monitor_all),
                                ):
                 cmd = cmd + ('--', 'set', 'open-vswitch', '.', ovs_ext_id)
             self.run(*cmd)

--- a/unit_tests/test_lib_charms_ovn_charm.py
+++ b/unit_tests/test_lib_charms_ovn_charm.py
@@ -492,6 +492,7 @@ class Helper(test_utils.PatchHelper):
                 'enable-dpdk': False,
                 'bridge-interface-mappings': 'br-ex:eth0',
                 'prefer-chassis-as-gw': False,
+                'ovn-monitor-all': False,
                 'vpd-device-spec':
                 '[{"bus": "pci", "vendor_id": "beef", "device_id": "cafe"}]',
             }
@@ -574,6 +575,7 @@ class TestDPDKOVNChassisCharmExtraLibs(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-ex other:br-data'),
             'prefer-chassis-as-gw': False,
+            'ovn-monitor-all': False,
             'dpdk-runtime-libraries': '',
             'vpd-device-spec': '',
             'ovn-source': 'distro',
@@ -760,6 +762,7 @@ class TestDPDKOVNChassisCharm(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-ex other:br-data'),
             'prefer-chassis-as-gw': False,
+            'ovn-monitor-all': False,
             'dpdk-runtime-libraries': '',
             'vpd-device-spec': '',
             'pmd-cpu-set': '',
@@ -1093,6 +1096,7 @@ class TestOVNChassisCharm(Helper):
             'ovn-bridge-mappings': (
                 'provider:br-provider other:br-other'),
             'prefer-chassis-as-gw': True,
+            'ovn-monitor-all': True,
             'vpd-device-spec':
             '[{"bus": "pci", "vendor_id": "beef", "device_id": "cafe"}]',
             'ovn-source': 'distro',
@@ -1236,6 +1240,8 @@ class TestOVNChassisCharm(Helper):
                 'external-ids:ovn-remote=fake-sb-conn-str',
                 '--', 'set', 'open-vswitch', '.',
                 'external_ids:ovn-match-northd-version=False',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-monitor-all=True',
             ),
         ])
         self.service_restart.assert_not_called()
@@ -1262,6 +1268,8 @@ class TestOVNChassisCharm(Helper):
                 'external-ids:ovn-remote=fake-sb-conn-str',
                 '--', 'set', 'open-vswitch', '.',
                 'external_ids:ovn-match-northd-version=False',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-monitor-all=True',
             ),
             mock.call('ovs-vsctl', '--id', '@manager',
                       'create', 'Manager', 'target="ptcp:6640:127.0.0.1"',
@@ -1300,6 +1308,8 @@ class TestOVNChassisCharm(Helper):
                 'external-ids:ovn-remote=fake-sb-conn-str',
                 '--', 'set', 'open-vswitch', '.',
                 'external_ids:ovn-match-northd-version=True',
+                '--', 'set', 'open-vswitch', '.',
+                'external-ids:ovn-monitor-all=True',
             ),
         ])
 


### PR DESCRIPTION
This commit adds the option 'ovn-monitor-all' to the OVN charm, allowing the operator to enable or disable monitoring of all records in the OVN_Southbound database by the ovn-controller.

- Updated config.yaml to include 'ovn-monitor-all' (default: false)
- Updated lib/charms/ovn_charm.py to handle the option in configure_bridges()
- Added unit tests

Closes-Bug: 2138758

cherry-picked from: 0a881e5de54d280a5fef1983cefa9cd64b9e7022